### PR TITLE
Implement basic remote control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # 991a-remote
+
+Dieses Projekt stellt ein einfaches Server-Client-System zum Fernsteuern eines Yaesu FT‑991A 
+inklusive Audioübertragung bereit. Sowohl der Server als auch der Client sind in Python implementiert
+und lauffähig unter Windows 11 (benötigt Python 3.9 oder neuer).
+
+## Aufbau
+
+- `server/control_server.py` – WebSocket-Server zur Steuerung des Transceivers über die CAT-Schnittstelle.
+- `server/audio_bridge.py`  – UDP Audio-Brücke (sendet Audio vom Funkgerät an den Client und umgekehrt).
+- `client/control_client.py` – Kommandozeilen-Client zur Steuerung des Geräts.
+- `client/audio_client.py`   – Audio-Client zur Sprachübertragung.
+- `requirements.txt`         – benötigte Python-Pakete.
+
+## Installation
+
+1. Python installieren (mindestens Version 3.9).
+2. Abhängigkeiten installieren:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Serielle Schnittstelle des FT‑991A am Server-Rechner ermitteln und in `server/control_server.py` anpassen.
+
+## Nutzung
+
+### Server-Seite
+
+1. `python server/control_server.py` starten, um CAT-Befehle anzunehmen.
+2. `python server/audio_bridge.py` starten, um Audio zu übertragen. Vorher `CLIENT_IP` in der Datei auf
+die IP des Clients setzen.
+
+### Client-Seite
+
+1. Audioübertragung starten:
+   ```bash
+   python client/audio_client.py --server <server-ip>
+   ```
+   (IP in der Datei ggf. anpassen.)
+2. Funkgerät steuern, z. B. Frequenz und Mode setzen:
+   ```bash
+   python client/control_client.py --server <server-ip> --freq 7100000 --mode 1
+   ```
+   PTT schalten:
+   ```bash
+   python client/control_client.py --server <server-ip> --ptt on
+   python client/control_client.py --server <server-ip> --ptt off
+   ```
+
+Die Implementierung ist bewusst einfach gehalten und soll als Ausgangsbasis für eigene Erweiterungen dienen.
+

--- a/client/audio_client.py
+++ b/client/audio_client.py
@@ -1,0 +1,31 @@
+import socket
+import pyaudio
+
+AUDIO_RATE = 16000
+AUDIO_FORMAT = pyaudio.paInt16
+CHANNELS = 1
+CHUNK = 1024
+
+SERVER_IP = '127.0.0.1'
+CLIENT_PORT = 9002
+SERVER_PORT = 9003
+
+p = pyaudio.PyAudio()
+input_stream = p.open(format=AUDIO_FORMAT, channels=CHANNELS, rate=AUDIO_RATE,
+                      input=True, frames_per_buffer=CHUNK)
+output_stream = p.open(format=AUDIO_FORMAT, channels=CHANNELS, rate=AUDIO_RATE,
+                       output=True, frames_per_buffer=CHUNK)
+
+sock_tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock_rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock_rx.bind(('0.0.0.0', CLIENT_PORT))
+
+print('Audio client running')
+while True:
+    data = input_stream.read(CHUNK, exception_on_overflow=False)
+    sock_tx.sendto(data, (SERVER_IP, SERVER_PORT))
+    try:
+        packet, _ = sock_rx.recvfrom(CHUNK * 2)
+        output_stream.write(packet)
+    except socket.error:
+        pass

--- a/client/control_client.py
+++ b/client/control_client.py
@@ -1,0 +1,41 @@
+import asyncio
+import json
+import websockets
+
+SERVER_IP = '127.0.0.1'
+
+async def send_command(command):
+    uri = f'ws://{SERVER_IP}:9001'
+    async with websockets.connect(uri) as websocket:
+        await websocket.send(json.dumps(command))
+        if command.get('command') == 'get_frequency':
+            resp = await websocket.recv()
+            print(resp)
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--freq', type=int, help='Set frequency in Hz')
+    parser.add_argument('--mode', type=int, help='Set mode number')
+    parser.add_argument('--ptt', choices=['on', 'off'], help='Key PTT on/off')
+    parser.add_argument('--query', action='store_true', help='Query frequency')
+    parser.add_argument('--server', default='127.0.0.1', help='Server IP')
+    args = parser.parse_args()
+    SERVER_IP = args.server
+
+    commands = []
+    if args.freq:
+        commands.append({'command': 'set_frequency', 'frequency': args.freq})
+    if args.mode is not None:
+        commands.append({'command': 'set_mode', 'mode': args.mode})
+    if args.ptt == 'on':
+        commands.append({'command': 'ptt_on'})
+    if args.ptt == 'off':
+        commands.append({'command': 'ptt_off'})
+    if args.query:
+        commands.append({'command': 'get_frequency'})
+
+    async def run():
+        for cmd in commands:
+            await send_command(cmd)
+    asyncio.run(run())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyserial
+websockets
+pyaudio

--- a/server/audio_bridge.py
+++ b/server/audio_bridge.py
@@ -1,0 +1,31 @@
+import socket
+import pyaudio
+
+AUDIO_RATE = 16000
+AUDIO_FORMAT = pyaudio.paInt16
+CHANNELS = 1
+CHUNK = 1024
+
+CLIENT_IP = '127.0.0.1'  # set to client IP
+CLIENT_PORT = 9002
+SERVER_PORT = 9003
+
+p = pyaudio.PyAudio()
+input_stream = p.open(format=AUDIO_FORMAT, channels=CHANNELS, rate=AUDIO_RATE,
+                      input=True, frames_per_buffer=CHUNK)
+output_stream = p.open(format=AUDIO_FORMAT, channels=CHANNELS, rate=AUDIO_RATE,
+                       output=True, frames_per_buffer=CHUNK)
+
+sock_tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock_rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock_rx.bind(('0.0.0.0', SERVER_PORT))
+
+print('Audio bridge running')
+while True:
+    data = input_stream.read(CHUNK, exception_on_overflow=False)
+    sock_tx.sendto(data, (CLIENT_IP, CLIENT_PORT))
+    try:
+        packet, _ = sock_rx.recvfrom(CHUNK * 2)
+        output_stream.write(packet)
+    except socket.error:
+        pass

--- a/server/control_server.py
+++ b/server/control_server.py
@@ -1,0 +1,39 @@
+import asyncio
+import json
+import serial
+import websockets
+
+SERIAL_PORT = 'COM3'  # adjust to the serial port of the FT-991A
+SERIAL_BAUDRATE = 9600
+
+async def handle_client(websocket, path):
+    ser = serial.Serial(SERIAL_PORT, SERIAL_BAUDRATE, timeout=1)
+    try:
+        async for message in websocket:
+            data = json.loads(message)
+            cmd = data.get('command')
+            if cmd == 'set_frequency':
+                freq = int(data['frequency'])
+                cat = f'FA{freq:011d};'
+                ser.write(cat.encode('ascii'))
+            elif cmd == 'set_mode':
+                mode = int(data['mode'])
+                cat = f'MD{mode:02d};'
+                ser.write(cat.encode('ascii'))
+            elif cmd == 'ptt_on':
+                ser.write(b'TX;')
+            elif cmd == 'ptt_off':
+                ser.write(b'RX;')
+            elif cmd == 'get_frequency':
+                ser.write(b'FA;')
+                resp = ser.readline().decode('ascii').strip()
+                await websocket.send(json.dumps({'frequency': resp}))
+    finally:
+        ser.close()
+
+async def main():
+    async with websockets.serve(handle_client, '0.0.0.0', 9001):
+        await asyncio.Future()  # run forever
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add Python server for controlling the FT-991A via CAT
- add audio bridge for UDP audio streaming
- add client scripts to send commands and audio
- document setup and usage in README

## Testing
- `python -m py_compile server/control_server.py server/audio_bridge.py client/control_client.py client/audio_client.py`


------
https://chatgpt.com/codex/tasks/task_e_6869378388fc832181af9f18930e68fb