### PR TITLE
Add remote control mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # 991a-remote
 
-Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerung eines Yaesu FT‑991A bereit. Der gesamte Funktionsumfang ist im Server umgesetzt, so dass keine separaten Client‑Skripte mehr notwendig sind.
+Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerung eines Yaesu FT‑991A bereit. Der Server kann direkt am Funkgerät laufen oder auf einen separaten Steuerungsdienst zugreifen.
 
 ## Aufbau
 
-- `server/flask_server.py` – Flask-Anwendung mit Login-Schutz, CAT-Steuerung und Audiobrücke per WebSocket
+- `server/flask_server.py` – Flask-Anwendung mit Login-Schutz und Weboberfläche
+- `server/ft991a_ws_server.py` – schlanker WebSocket-Server zur CAT-Steuerung auf dem Windows‑Rechner
 - `server/templates/` – HTML-Vorlagen für Login und Steuerungsseite
 - `requirements.txt` – benötigte Python-Pakete
 
@@ -19,15 +20,21 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
 
 ## Nutzung
 
-1. Den Server auf dem Rechner mit angeschlossenem FT‑991A starten:
+### Server am Funkgerät (Windows)
+
+1. Auf dem Windows‑Rechner mit angeschlossenem FT‑991A den Steuerungsdienst starten:
    ```bash
-   python server/flask_server.py --serial-port COM3 --username admin --password secret
+   python server/ft991a_ws_server.py --serial-port COM3
    ```
-   Der Parameter `--serial-port` muss an den verwendeten COM-Port angepasst werden. 
-   Die Anwendung lauscht anschließend auf Port 8000 (anpassbar mit `--http-port`)
-   und verlangt beim Aufruf im Browser Benutzername und Passwort.
-2. Nach erfolgreichem Login können Frequenz, Modus und PTT gesteuert werden. 
-   Zudem steht ein Feld für beliebige CAT-Befehle zur Verfügung. 
-   Mit "Start Audio" wird eine bidirektionale Audioübertragung über WebSocket aufgebaut.
+   Der COM‑Port ist ggf. anzupassen. Der Dienst lauscht auf Port 9001 für WebSocket‑Verbindungen.
+
+### Flask‑Server auf dem Client (Linux)
+
+1. Auf dem Linux‑Rechner die Weboberfläche starten und mit dem obigen Dienst verbinden:
+   ```bash
+   python server/flask_server.py --server ws://<windows-ip>:9001 --username admin --password secret
+   ```
+   Die Anwendung läuft auf Port 8000 (anpassbar mit `--http-port`) und verlangt beim Aufruf im Browser Benutzername und Passwort.
+2. Nach erfolgreichem Login können Frequenz, Modus und PTT gesteuert werden. Zudem steht ein Feld für beliebige CAT-Befehle zur Verfügung.
 
 Die Implementierung bildet nur grundlegende Funktionen ab und kann als Grundlage für eigene Erweiterungen dienen.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyserial
 pyaudio
 flask
 flask-sock
+websockets

--- a/server/ft991a_ws_server.py
+++ b/server/ft991a_ws_server.py
@@ -1,0 +1,60 @@
+import argparse
+import asyncio
+import json
+import serial
+import websockets
+
+DEFAULT_SERIAL_PORT = 'COM3'
+DEFAULT_BAUDRATE = 9600
+DEFAULT_WS_PORT = 9001
+
+ser = None
+ser_lock = asyncio.Lock()
+
+async def handle_client(websocket):
+    async for message in websocket:
+        data = json.loads(message)
+        cmd = data.get('command')
+        async with ser_lock:
+            if cmd == 'set_frequency':
+                try:
+                    freq = int(data['frequency'])
+                    ser.write(f'FA{freq:011d};'.encode('ascii'))
+                except (KeyError, ValueError):
+                    pass
+            elif cmd == 'set_mode':
+                try:
+                    mode = int(data['mode'])
+                    ser.write(f'MD{mode:02d};'.encode('ascii'))
+                except (KeyError, ValueError):
+                    pass
+            elif cmd == 'ptt_on':
+                ser.write(b'TX;')
+            elif cmd == 'ptt_off':
+                ser.write(b'RX;')
+            elif cmd == 'cat':
+                value = data.get('data', '')
+                if not value.endswith(';'):
+                    value += ';'
+                ser.write(value.encode('ascii'))
+
+async def main():
+    global ser
+    parser = argparse.ArgumentParser(description='FT-991A control server')
+    parser.add_argument('--serial-port', default=DEFAULT_SERIAL_PORT,
+                        help='FT-991A serial port')
+    parser.add_argument('--baudrate', type=int, default=DEFAULT_BAUDRATE,
+                        help='Serial baud rate')
+    parser.add_argument('--ws-port', type=int, default=DEFAULT_WS_PORT,
+                        help='WebSocket port')
+    args = parser.parse_args()
+
+    ser = serial.Serial(args.serial_port, args.baudrate, timeout=1)
+    try:
+        async with websockets.serve(handle_client, '0.0.0.0', args.ws_port):
+            await asyncio.Future()  # run forever
+    finally:
+        ser.close()
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- create `ft991a_ws_server.py` to run on Windows with the transceiver
- allow `flask_server.py` to act as client via `--server` option
- document the Windows server/Linux Flask client workflow
- require `websockets` in requirements

## Testing
- `python -m py_compile server/flask_server.py server/ft991a_ws_server.py`
- `pip install -r requirements.txt` *(fails: portaudio missing)*

------
https://chatgpt.com/codex/tasks/task_e_68699d5529ec8321ab02b32d61302741