### PR TITLE
Allow audio device selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
    ```bash
    pip install -r requirements.txt
    ```
-3. Optional: Serielle Schnittstelle und Zugangsdaten können beim Start der Anwendung angegeben werden.
+3. Optional: Serielle Schnittstelle, Audio-Geräte und Zugangsdaten können beim Start der Anwendung angegeben werden.
 
 ## Nutzung
 
@@ -30,11 +30,23 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
 
 ### Flask‑Server auf dem Client (Linux)
 
-1. Auf dem Linux‑Rechner die Weboberfläche starten und mit dem obigen Dienst verbinden:
+1. Auf dem Linux‑Rechner die Weboberfläche starten. Standardmäßig wird die Verbindung zum Dienst unter `ws://911a.lima11.de:9001` aufgebaut:
    ```bash
-   python server/flask_server.py --server ws://<windows-ip>:9001 --username admin --password secret
+   python server/flask_server.py --username admin --password secret
    ```
-   Die Anwendung läuft auf Port 8000 (anpassbar mit `--http-port`) und verlangt beim Aufruf im Browser Benutzername und Passwort.
+   Abweichend lässt sich mit `--server` eine andere Adresse angeben. Die Anwendung läuft auf Port 8000 (anpassbar mit `--http-port`) und verlangt beim Aufruf im Browser Benutzername und Passwort.
+   Über `--list-devices` lassen sich verfügbare Audio‑Geräte anzeigen. Mit
+   `--input-device` und `--output-device` kann anschließend die gewünschte
+   Geräte‑Nummer gewählt werden.
 2. Nach erfolgreichem Login können Frequenz, Modus und PTT gesteuert werden. Zudem steht ein Feld für beliebige CAT-Befehle zur Verfügung.
 
 Die Implementierung bildet nur grundlegende Funktionen ab und kann als Grundlage für eigene Erweiterungen dienen.
+
+## Wichtige CAT-Befehle
+
+| Befehl | Beschreibung |
+| ------ | ------------ |
+| `FAxxxxxxx;` | VFO-A Frequenz einstellen (lesen mit `FA;`) |
+| `MDxx;` | Betriebsart einstellen (lesen mit `MD;`) |
+| `TX;` | PTT aktivieren |
+| `RX;` | PTT deaktivieren |

--- a/server/ft991a_ws_server.py
+++ b/server/ft991a_ws_server.py
@@ -37,6 +37,14 @@ async def handle_client(websocket):
                 if not value.endswith(';'):
                     value += ';'
                 ser.write(value.encode('ascii'))
+            elif cmd == 'get_frequency':
+                ser.write(b'FA;')
+                reply = ser.readline().decode('ascii', errors='ignore').strip()
+                await websocket.send(json.dumps({'response': reply}))
+            elif cmd == 'get_mode':
+                ser.write(b'MD;')
+                reply = ser.readline().decode('ascii', errors='ignore').strip()
+                await websocket.send(json.dumps({'response': reply}))
 
 async def main():
     global ser

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -24,6 +24,14 @@
         <input type="hidden" name="cmd" value="ptt_off">
         <button type="submit">PTT OFF</button>
     </form>
+    <form method="post" action="{{ url_for('command') }}" class="cmdForm">
+        <input type="hidden" name="cmd" value="get_frequency">
+        <button type="submit">Read Frequency</button>
+    </form>
+    <form method="post" action="{{ url_for('command') }}" class="cmdForm">
+        <input type="hidden" name="cmd" value="get_mode">
+        <button type="submit">Read Mode</button>
+    </form>
     <form method="post" action="{{ url_for('command') }}">
         <label>CAT Command: <input type="text" name="value" placeholder="EX;"/></label>
         <input type="hidden" name="cmd" value="cat">
@@ -75,7 +83,9 @@ function stopAudio(){
 document.querySelectorAll('.cmdForm').forEach(f => {
     f.addEventListener('submit', e => {
         e.preventDefault();
-        fetch(f.action, {method:'POST', body:new FormData(f)});
+        fetch(f.action, {method:'POST', body:new FormData(f)})
+            .then(r => r.text())
+            .then(t => { if(t) alert(t); });
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- add command line options to choose audio devices
- expose `--list-devices` helper
- allow reading frequency and mode via new CAT commands
- surface results in the web UI
- document audio options and CAT commands
- connect to default domain `911a.lima11.de`

## Testing
- `python -m py_compile server/flask_server.py server/ft991a_ws_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68699effe5548321a03498f3f78cd983