### PR TITLE
Add repeater and audio controls

### DIFF
--- a/server/flask_server.py
+++ b/server/flask_server.py
@@ -93,6 +93,35 @@ def command():
             data = {'command': 'ptt_on'}
         elif cmd == 'ptt_off':
             data = {'command': 'ptt_off'}
+        elif cmd == 'shift':
+            if value in ('0', '1', '2'):
+                data = {'command': 'cat', 'data': f'RT{value};'}
+            else:
+                return ('', 204)
+        elif cmd == 'offset':
+            try:
+                off = int(value)
+                data = {'command': 'cat', 'data': f'OF{off:07d};'}
+            except ValueError:
+                return ('', 204)
+        elif cmd == 'ctcss':
+            try:
+                tone = float(value)
+                data = {'command': 'cat', 'data': f'CT{int(tone*10):04d};'}
+            except ValueError:
+                return ('', 204)
+        elif cmd == 'dcs':
+            try:
+                code = int(value)
+                data = {'command': 'cat', 'data': f'DS{code:03d};'}
+            except ValueError:
+                return ('', 204)
+        elif cmd == 'mic_gain':
+            try:
+                gain = int(value)
+                data = {'command': 'cat', 'data': f'MG{gain:03d};'}
+            except ValueError:
+                return ('', 204)
         elif cmd == 'cat':
             if not value.endswith(';'):
                 value += ';'
@@ -131,6 +160,35 @@ def command():
             data = {'command': 'ptt_on'}
         elif cmd == 'ptt_off':
             data = {'command': 'ptt_off'}
+        elif cmd == 'shift':
+            if value in ('0', '1', '2'):
+                data = {'command': 'cat', 'data': f'RT{value};'}
+            else:
+                return ('', 204)
+        elif cmd == 'offset':
+            try:
+                off = int(value)
+                data = {'command': 'cat', 'data': f'OF{off:07d};'}
+            except ValueError:
+                return ('', 204)
+        elif cmd == 'ctcss':
+            try:
+                tone = float(value)
+                data = {'command': 'cat', 'data': f'CT{int(tone*10):04d};'}
+            except ValueError:
+                return ('', 204)
+        elif cmd == 'dcs':
+            try:
+                code = int(value)
+                data = {'command': 'cat', 'data': f'DS{code:03d};'}
+            except ValueError:
+                return ('', 204)
+        elif cmd == 'mic_gain':
+            try:
+                gain = int(value)
+                data = {'command': 'cat', 'data': f'MG{gain:03d};'}
+            except ValueError:
+                return ('', 204)
         elif cmd == 'cat':
             if not value.endswith(';'):
                 value += ';'
@@ -165,6 +223,35 @@ def command():
             ser.write(b'TX;')
         elif cmd == 'ptt_off':
             ser.write(b'RX;')
+        elif cmd == 'shift':
+            if value in ('0', '1', '2'):
+                ser.write(f'RT{value};'.encode('ascii'))
+            else:
+                pass
+        elif cmd == 'offset':
+            try:
+                off = int(value)
+                ser.write(f'OF{off:07d};'.encode('ascii'))
+            except ValueError:
+                pass
+        elif cmd == 'ctcss':
+            try:
+                tone = float(value)
+                ser.write(f'CT{int(tone*10):04d};'.encode('ascii'))
+            except ValueError:
+                pass
+        elif cmd == 'dcs':
+            try:
+                code = int(value)
+                ser.write(f'DS{code:03d};'.encode('ascii'))
+            except ValueError:
+                pass
+        elif cmd == 'mic_gain':
+            try:
+                gain = int(value)
+                ser.write(f'MG{gain:03d};'.encode('ascii'))
+            except ValueError:
+                pass
         elif cmd == 'cat':
             if not value.endswith(';'):
                 value += ';'

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -17,6 +17,37 @@
         <button type="submit">Set Mode</button>
     </form>
     <form method="post" action="{{ url_for('command') }}" class="cmdForm">
+        <label>Shift:
+            <select name="value">
+                <option value="0">Simplex</option>
+                <option value="1">-</option>
+                <option value="2">+</option>
+            </select>
+        </label>
+        <input type="hidden" name="cmd" value="shift">
+        <button type="submit">Set Shift</button>
+    </form>
+    <form method="post" action="{{ url_for('command') }}" class="cmdForm">
+        <label>Offset (Hz): <input type="text" name="value"></label>
+        <input type="hidden" name="cmd" value="offset">
+        <button type="submit">Set Offset</button>
+    </form>
+    <form method="post" action="{{ url_for('command') }}" class="cmdForm">
+        <label>CTCSS (Hz): <input type="text" name="value"></label>
+        <input type="hidden" name="cmd" value="ctcss">
+        <button type="submit">Set CTCSS</button>
+    </form>
+    <form method="post" action="{{ url_for('command') }}" class="cmdForm">
+        <label>DCS Code: <input type="text" name="value"></label>
+        <input type="hidden" name="cmd" value="dcs">
+        <button type="submit">Set DCS</button>
+    </form>
+    <form method="post" action="{{ url_for('command') }}" class="cmdForm">
+        <label>MIC Gain: <input type="text" name="value"></label>
+        <input type="hidden" name="cmd" value="mic_gain">
+        <button type="submit">Set MIC Gain</button>
+    </form>
+    <form method="post" action="{{ url_for('command') }}" class="cmdForm">
         <input type="hidden" name="cmd" value="ptt_on">
         <button type="submit">PTT ON</button>
     </form>


### PR DESCRIPTION
## Summary
- allow setting shift, offset, CTCSS, DCS and MIC gain
- add new forms for the above controls on the control page

## Testing
- `python -m py_compile server/flask_server.py server/ft991a_ws_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6869a4858d748321add81eca78954edf