### PR TITLE
Add multi rig connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
 ## Aufbau
 
 - `server/flask_server.py` – Flask-Anwendung mit Login-Schutz und Weboberfläche
-- `server/ft991a_ws_server.py` – schlanker WebSocket-Server zur CAT-Steuerung auf dem Windows‑Rechner
+- `server/ft991a_ws_server.py` – schlanker WebSocket-Server zur CAT-Steuerung auf dem Windows‑Rechner; meldet sich mit einem frei wählbaren Rufzeichen
 - `server/templates/` – HTML-Vorlagen für Login und Steuerungsseite
 - `requirements.txt` – benötigte Python-Pakete
 
@@ -26,9 +26,12 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
    eine Verbindung zum Flask‑Server aufbauen:
    ```bash
    python server/ft991a_ws_server.py --serial-port COM3 \
-       --connect ws://991a.lima11.de:8000/ws/rig
+       --connect ws://991a.lima11.de:8000/ws/rig \
+       --callsign MYCALL
    ```
    Der COM‑Port ist ggf. anzupassen.
+   Das Rufzeichen wird an den Flask‑Server übertragen. Verbinden sich mehrere
+   Stationen, kann auf der Weboberfläche eine davon ausgewählt werden.
 
 ### Flask‑Server auf dem Client (Linux)
 

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -6,6 +6,20 @@
 <body>
     <h1>FT-991A Control</h1>
     <p><a href="{{ url_for('logout') }}">Logout</a></p>
+    {% if rigs %}
+    <form method="post" action="{{ url_for('select_rig') }}">
+        <label>Rig:
+            <select name="rig">
+            {% for r in rigs %}
+                <option value="{{ r }}" {% if r==selected_rig %}selected{% endif %}>{{ r }}</option>
+            {% endfor %}
+            </select>
+        </label>
+        <button type="submit">Select</button>
+    </form>
+    {% else %}
+    <p>No rig connected.</p>
+    {% endif %}
     <form method="post" action="{{ url_for('command') }}" class="cmdForm">
         <label>Frequency (Hz): <input type="text" name="value"></label>
         <input type="hidden" name="cmd" value="frequency">


### PR DESCRIPTION
## Summary
- allow multiple remote rigs to connect and select them in the UI
- send station callsign from rig server to Flask server
- update documentation for the new callsign parameter

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6869a68d21e4832185350b87854c6007