### PR TITLE
Implement operator assignment for multiple users

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
    Über `--list-devices` lassen sich verfügbare Audio‑Geräte anzeigen. Mit
    `--input-device` und `--output-device` kann anschließend die gewünschte
    Geräte‑Nummer gewählt werden.
-2. Nach erfolgreichem Login können Frequenz, Modus und PTT gesteuert werden. Zudem steht ein Feld für beliebige CAT-Befehle zur Verfügung.
+2. Nach erfolgreichem Login kann sich jeder Benutzer mit einem frei wählbaren Nutzernamen anmelden. Pro angeschlossenem 991A kann genau ein Nutzer die Rolle des Operators übernehmen und das Gerät steuern. Alle weiteren eingeloggten Nutzer können den Audiostream im sogenannten SWL-Modus mithören.
 
 Die Implementierung bildet nur grundlegende Funktionen ab und kann als Grundlage für eigene Erweiterungen dienen.
 

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -17,9 +17,24 @@
         </label>
         <button type="submit">Select</button>
     </form>
+    <p>Operator: {{ operator or 'none' }}</p>
+    {% if operator == user %}
+    <form method="post" action="{{ url_for('release_control') }}">
+        <button type="submit">Release Control</button>
+    </form>
+    {% elif not operator %}
+    <form method="post" action="{{ url_for('take_control') }}">
+        <button type="submit">Take Control</button>
+    </form>
+    {% else %}
+    <form method="post" action="{{ url_for('take_control') }}">
+        <button type="submit" disabled>Take Control</button>
+    </form>
+    {% endif %}
     {% else %}
     <p>No rig connected.</p>
     {% endif %}
+    {% if operator == user %}
     <form method="post" action="{{ url_for('command') }}" class="cmdForm">
         <label>Frequency (Hz): <input type="text" name="value"></label>
         <input type="hidden" name="cmd" value="frequency">
@@ -82,6 +97,7 @@
         <input type="hidden" name="cmd" value="cat">
         <button type="submit">Send CAT</button>
     </form>
+    {% endif %}
     <button onclick="startAudio()">Start Audio</button>
     <button onclick="stopAudio()">Stop Audio</button>
 <script>


### PR DESCRIPTION
## Summary
- add per-rig operator management
- allow arbitrary usernames at login
- restrict rig commands to the selected operator
- show control status in the UI
- document the operator/SWL concept

## Testing
- `python -m py_compile server/flask_server.py`
- `python -m py_compile server/ft991a_ws_server.py`
- `pip install -r requirements.txt` *(fails: pyaudio build error)*

------
https://chatgpt.com/codex/tasks/task_e_6869a87bdb3883219e855cd3ef321899