### PR TITLE
Add user registration and admin approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
 
 1. Auf dem Linux‑Rechner die Weboberfläche starten. Der Server wartet auf eine eingehende Verbindung des Steuerungsdienstes:
    ```bash
-   python server/flask_server.py --username admin --password secret
+   python server/flask_server.py
    ```
-   Mit dem Parameter `--server` kann optional weiterhin ein externer Dienst angesprochen werden. Die Anwendung läuft auf Port 8000 (anpassbar mit `--http-port`) und verlangt beim Aufruf im Browser Benutzername und Passwort.
+   Mit dem Parameter `--server` kann optional weiterhin ein externer Dienst angesprochen werden. Die Anwendung läuft auf Port 8000 (anpassbar mit `--http-port`).
+   Beim ersten Start existiert lediglich der Benutzer `admin` mit dem Passwort `admin`. Dieses Konto muss sich nach dem Login umbenennen und ein neues Passwort vergeben.
+   Weitere Benutzer können sich anschließend selbst registrieren und müssen vom Administrator freigeschaltet werden, bevor sie das Gerät bedienen dürfen.
    Über `--list-devices` lassen sich verfügbare Audio‑Geräte anzeigen. Mit
    `--input-device` und `--output-device` kann anschließend die gewünschte
    Geräte‑Nummer gewählt werden.
-2. Nach erfolgreichem Login kann sich jeder Benutzer mit einem frei wählbaren Nutzernamen anmelden. Pro angeschlossenem 991A kann genau ein Nutzer die Rolle des Operators übernehmen und das Gerät steuern. Alle weiteren eingeloggten Nutzer können den Audiostream im sogenannten SWL-Modus mithören.
+2. Benutzer registrieren sich über die Weboberfläche mit ihrem Rufzeichen und einem Passwort. Erst nach Freischaltung durch einen Administrator dürfen sie das Gerät als Operator bedienen. Bis dahin können sie lediglich im SWL-Modus zuhören.
 
 Die Implementierung bildet nur grundlegende Funktionen ab und kann als Grundlage für eigene Erweiterungen dienen.
 

--- a/server/templates/change_credentials.html
+++ b/server/templates/change_credentials.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Change Credentials</title>
+</head>
+<body>
+    <h1>Change Credentials</h1>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="post">
+        <label>Username: <input type="text" name="username" value="{{ current }}"></label><br>
+        <label>New Password: <input type="password" name="password"></label><br>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -5,7 +5,12 @@
 </head>
 <body>
     <h1>FT-991A Control</h1>
-    <p><a href="{{ url_for('logout') }}">Logout</a></p>
+    <p><a href="{{ url_for('logout') }}">Logout</a>
+    {% if role == 'admin' %}| <a href="{{ url_for('admin_users') }}">User Admin</a>{% endif %}</p>
+    <p>Logged in as {{ user }} ({{ role }})</p>
+    {% if not approved and role != 'admin' %}
+    <p style="color:orange;">Waiting for approval. You can only listen.</p>
+    {% endif %}
     {% if rigs %}
     <form method="post" action="{{ url_for('select_rig') }}">
         <label>Rig:
@@ -18,23 +23,25 @@
         <button type="submit">Select</button>
     </form>
     <p>Operator: {{ operator or 'none' }}</p>
-    {% if operator == user %}
-    <form method="post" action="{{ url_for('release_control') }}">
-        <button type="submit">Release Control</button>
-    </form>
-    {% elif not operator %}
-    <form method="post" action="{{ url_for('take_control') }}">
-        <button type="submit">Take Control</button>
-    </form>
-    {% else %}
-    <form method="post" action="{{ url_for('take_control') }}">
-        <button type="submit" disabled>Take Control</button>
-    </form>
+    {% if role == 'admin' or approved %}
+        {% if operator == user %}
+        <form method="post" action="{{ url_for('release_control') }}">
+            <button type="submit">Release Control</button>
+        </form>
+        {% elif not operator %}
+        <form method="post" action="{{ url_for('take_control') }}">
+            <button type="submit">Take Control</button>
+        </form>
+        {% else %}
+        <form method="post" action="{{ url_for('take_control') }}">
+            <button type="submit" disabled>Take Control</button>
+        </form>
+        {% endif %}
     {% endif %}
     {% else %}
     <p>No rig connected.</p>
     {% endif %}
-    {% if operator == user %}
+    {% if (role == 'admin' or approved) and operator == user %}
     <form method="post" action="{{ url_for('command') }}" class="cmdForm">
         <label>Frequency (Hz): <input type="text" name="value"></label>
         <input type="hidden" name="cmd" value="frequency">

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -6,10 +6,12 @@
 <body>
     <h1>Login</h1>
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    {% if message %}<p style="color:green;">{{ message }}</p>{% endif %}
     <form method="post">
         <label>Username: <input type="text" name="username"></label><br>
         <label>Password: <input type="password" name="password"></label><br>
         <button type="submit">Login</button>
     </form>
+    <p><a href="{{ url_for('register') }}">Register</a></p>
 </body>
 </html>

--- a/server/templates/register.html
+++ b/server/templates/register.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Register</title>
+</head>
+<body>
+    <h1>Register</h1>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="post">
+        <label>Callsign: <input type="text" name="username"></label><br>
+        <label>Password: <input type="password" name="password"></label><br>
+        <button type="submit">Register</button>
+    </form>
+    <p><a href="{{ url_for('login') }}">Back to Login</a></p>
+</body>
+</html>

--- a/server/templates/userlist.html
+++ b/server/templates/userlist.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>User Administration</title>
+</head>
+<body>
+    <h1>User Administration</h1>
+    <table border="1">
+        <tr><th>User</th><th>Role</th><th>Approved</th><th>Actions</th></tr>
+        {% for name, u in users.items() %}
+        <tr>
+            <td>{{ name }}</td>
+            <td>{{ u.role }}</td>
+            <td>{{ 'yes' if u.approved else 'no' }}</td>
+            <td>
+                <form method="post" style="display:inline">
+                    <input type="hidden" name="username" value="{{ name }}">
+                    <input type="hidden" name="action" value="approve">
+                    <button type="submit">Approve</button>
+                </form>
+                <form method="post" style="display:inline">
+                    <input type="hidden" name="username" value="{{ name }}">
+                    <input type="hidden" name="action" value="make_admin">
+                    <button type="submit">Make Admin</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+    <p><a href="{{ url_for('index') }}">Back</a></p>
+</body>
+</html>

--- a/users.json
+++ b/users.json
@@ -1,0 +1,8 @@
+{
+  "admin": {
+    "password": "scrypt:32768:8:1$TcoiTY1bQX5Custw$cbf8852fd0b17a1f48e61b2eeb1f9888bf20c10594e0ca9c3cf94920e5fc711ad5f3775f396ab33f7a9096d3c314af828ce603ebb9a48efc064a2a65030a1632",
+    "role": "admin",
+    "approved": true,
+    "needs_change": true
+  }
+}


### PR DESCRIPTION
## Summary
- create simple user database with default `admin` account
- implement registration, credential change and admin user management
- block rig control until a user is approved
- add HTML templates for new pages and update existing ones
- document the new login workflow in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa9ab9cc832183cf9c6a98f2bf1b