### PR TITLE
Warn when TRX not connected

### DIFF
--- a/server/ft991a_ws_server.py
+++ b/server/ft991a_ws_server.py
@@ -2,6 +2,8 @@ import argparse
 import asyncio
 import json
 import serial
+from serial import SerialException
+import sys
 import websockets
 
 DEFAULT_SERIAL_PORT = 'COM3'
@@ -85,7 +87,11 @@ async def main():
     CALLSIGN = args.callsign
     ser = None
     if args.mode == 'trx':
-        ser = serial.Serial(args.serial_port, args.baudrate, timeout=1)
+        try:
+            ser = serial.Serial(args.serial_port, args.baudrate, timeout=1)
+        except SerialException:
+            print('Hinweis: Kein TRX verbunden.', flush=True)
+            return
     try:
         handshake = {'callsign': CALLSIGN}
         if args.username and args.password:

--- a/server/ft991a_ws_server.py
+++ b/server/ft991a_ws_server.py
@@ -3,7 +3,6 @@ import asyncio
 import json
 import serial
 from serial import SerialException
-import sys
 import websockets
 
 DEFAULT_SERIAL_PORT = 'COM3'

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -52,7 +52,7 @@
         {% endif %}
     {% endif %}
     {% else %}
-    <p>Kein Ger&auml;t verbunden.</p>
+    <p>Hinweis: Kein TRX verbunden.</p>
     {% endif %}
     {% if (role == 'admin' or approved) and operator == user %}
     <form method="post" action="{{ url_for('command') }}" class="cmdForm">


### PR DESCRIPTION
## Summary
- show a warning when the serial port for the TRX can't be opened

## Testing
- `python -m py_compile server/*.py`
- `python server/ft991a_ws_server.py --serial-port /dev/nonexistent --mode trx --connect ''`

------
https://chatgpt.com/codex/tasks/task_e_6869bd45d2748321b5c7f6337900a5d8