### PR TITLE
Display operator status

### DIFF
--- a/server/flask_server.py
+++ b/server/flask_server.py
@@ -130,9 +130,20 @@ def index():
     approved = session.get('approved')
     with OPERATOR_LOCK:
         operator = OPERATORS.get(selected)
-    return render_template('index.html', rigs=rigs, selected_rig=selected,
-                           operator=operator, user=user, role=role,
-                           approved=approved, year=CURRENT_YEAR)
+    operator_status = None
+    if operator:
+        with USERS_LOCK:
+            op_data = USERS.get(operator)
+        if op_data:
+            if op_data.get('role') == 'admin' or op_data.get('approved'):
+                operator_status = 'Operator'
+            else:
+                operator_status = 'SWL'
+    return render_template(
+        'index.html', rigs=rigs, selected_rig=selected,
+        operator=operator, operator_status=operator_status,
+        user=user, role=role,
+        approved=approved, year=CURRENT_YEAR)
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -35,7 +35,13 @@
         </label>
         <button type="submit">Ausw&auml;hlen</button>
     </form>
-    <p>Bediener: {{ operator or 'keiner' }}</p>
+    <p>Bediener:
+        {% if operator %}
+            {{ operator }} ({{ operator_status or 'Unbekannt' }})
+        {% else %}
+            keiner
+        {% endif %}
+    </p>
     {% if role == 'admin' or approved %}
         {% if operator == user %}
         <form method="post" action="{{ url_for('release_control') }}">


### PR DESCRIPTION
## Summary
- show operator status on selected rig
- display operator status in the UI

## Testing
- `python -m py_compile server/flask_server.py server/ft991a_ws_server.py`
- `pip install -r requirements.txt` *(fails: pyaudio build error)*

------
https://chatgpt.com/codex/tasks/task_e_6869c22b35d8832195dfd817dc810fb3