### PR TITLE
Style page like radio

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -12,10 +12,29 @@ body {
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
+.radio-case {
+    background:#333;
+    color:#eee;
+    border:4px solid #555;
+    border-radius:12px;
+    box-shadow:0 0 10px rgba(0,0,0,0.5);
+}
+
+.radio-display {
+    background:#111;
+    border:2px inset #444;
+    border-radius:6px;
+    color:#0f0;
+    font-family:monospace;
+    margin:-20px -20px 20px;
+    padding:1em;
+}
+
+.radio-display nav a { color:#0f0; }
 .controls-info ul {
     margin-top: 0;
 }
-header {
+header:not(.radio-display) {
     background:#007bff;
     color:#fff;
     padding:1em;
@@ -40,10 +59,17 @@ button[disabled] {
     background:#ccc;
     cursor:not-allowed;
 }
-main {
+main,
+.controls {
     display:flex;
     flex-direction:column;
     gap:1em;
+}
+.cmdForm {
+    display:flex;
+    align-items:center;
+    gap:0.5em;
+    flex-wrap:wrap;
 }
 footer {
     text-align:center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,13 +6,13 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
-<div class="container">
-<header>
+<div class="container radio-case">
+<header class="radio-display">
     <h1>FT-991A Steuerung</h1>
     <nav><a href="{{ url_for('logout') }}">Abmelden</a>{% if role == 'admin' %} | <a href="{{ url_for('admin_users') }}">Benutzerverwaltung</a>{% endif %}</nav>
 </header>
     <p>Angemeldet als {{ user }} ({{ role }})</p>
-<main>
+<main class="controls">
     <section class="controls-info">
         <h2>Wichtige Bedienelemente am FT-991A</h2>
         <ul>


### PR DESCRIPTION
## Summary
- style the radio web UI with a darker radio look
- update index page layout for new styles

## Testing
- `python -m py_compile flask_server.py`
- `pip install pyserial pyaudio flask flask_sock websockets --quiet` *(fails: portaudio.h missing)*
- `python flask_server.py --help` *(fails: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_686a68b3026083218e0333ef8af330ae