### PR TITLE
Add S‑meter support

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -415,13 +415,15 @@ def command():
             data = {'command': 'get_frequency'}
         elif cmd == 'get_mode':
             data = {'command': 'get_mode'}
+        elif cmd == 'get_smeter':
+            data = {'command': 'get_smeter'}
         else:
             return ('', 204)
 
         async def send():
             async with websockets.connect(REMOTE_SERVER) as ws:
                 await ws.send(json.dumps(data))
-                if cmd in ('get_frequency', 'get_mode'):
+                if cmd in ('get_frequency', 'get_mode', 'get_smeter'):
                     return await ws.recv()
             return None
         resp = asyncio.run(send())
@@ -487,12 +489,14 @@ def command():
             data = {'command': 'get_frequency'}
         elif cmd == 'get_mode':
             data = {'command': 'get_mode'}
+        elif cmd == 'get_smeter':
+            data = {'command': 'get_smeter'}
         else:
             return ('', 204)
 
         with RIG_LOCK:
             ws.send(json.dumps(data))
-            if cmd in ('get_frequency', 'get_mode'):
+            if cmd in ('get_frequency', 'get_mode', 'get_smeter'):
                 resp = ws.receive()
                 if resp:
                     return resp
@@ -552,6 +556,10 @@ def command():
         elif cmd == 'get_mode':
             ser.write(b'MD;')
             ser.readline()
+        elif cmd == 'get_smeter':
+            ser.write(b'SM;')
+            reply = ser.readline()
+            return reply.decode('ascii', errors='ignore')
     return ('', 204)
 
 @sock.route('/ws/audio')

--- a/static/style.css
+++ b/static/style.css
@@ -131,6 +131,19 @@ footer {
     text-align:right;
     color:#0ff;
 }
+.s-meter {
+    width:100%;
+    height:10px;
+    margin-top:10px;
+    border:1px solid #0ff;
+    background:#111;
+    position:relative;
+}
+.s-meter .bar {
+    height:100%;
+    width:0;
+    background:#0f0;
+}
 .vfo { flex:1; display:flex; justify-content:center; }
 .vfo-knob {
     width:160px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
         <div class="front-panel">
             <div class="screen">
                 <div class="freq-display">14.074.000</div>
+                <div class="s-meter"><div class="bar"></div></div>
             </div>
             <div class="vfo">
                 <div class="vfo-knob"></div>
@@ -156,6 +157,7 @@
 <script>
 let sock;
 let processor;
+let smTimer;
 function startAudio(){
     sock = new WebSocket('ws://' + location.host + '/ws/audio');
     sock.binaryType = 'arraybuffer';
@@ -194,6 +196,18 @@ function stopAudio(){
     if(processor){ processor.disconnect(); processor=null; }
     if(sock){ sock.close(); sock=null; }
 }
+function updateSM(){
+    fetch('{{ url_for('command') }}', {method:'POST', body:new URLSearchParams({'cmd':'get_smeter'})})
+        .then(r=>r.text()).then(t=>{
+            if(t){
+                const v=parseInt(t.match(/\d+/));
+                const pct=Math.min(100,Math.max(0, (v/255)*100));
+                document.querySelector('.s-meter .bar').style.width=pct+'%';
+            }
+        });
+}
+function startSM(){ if(!smTimer){ smTimer=setInterval(updateSM,1000); } }
+function stopSM(){ if(smTimer){ clearInterval(smTimer); smTimer=null; } }
 document.querySelectorAll('.cmdForm').forEach(f => {
     f.addEventListener('submit', e => {
         e.preventDefault();
@@ -202,6 +216,7 @@ document.querySelectorAll('.cmdForm').forEach(f => {
             .then(t => { if(t) alert(t); });
     });
 });
+startSM();
 </script>
 </body>
 </html>

--- a/trx/ft991a_ws_server.py
+++ b/trx/ft991a_ws_server.py
@@ -67,6 +67,10 @@ async def handle_client(websocket, announce=None):
                 ser.write(b'MD;')
                 reply = ser.readline().decode('ascii', errors='ignore').strip()
                 await websocket.send(json.dumps({'response': reply}))
+            elif cmd == 'get_smeter':
+                ser.write(b'SM;')
+                reply = ser.readline().decode('ascii', errors='ignore').strip()
+                await websocket.send(json.dumps({'response': reply}))
 
 async def client_loop(uri, handshake):
     while True:


### PR DESCRIPTION
## Summary
- add S‑meter bar to front panel
- poll new `get_smeter` command periodically
- implement `get_smeter` in the Flask server and websocket helper

## Testing
- `python -m py_compile flask_server.py trx/ft991a_ws_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686a71ee4af88321b35fd1278a9c1467