### PR TITLE
Add ping RTT monitoring

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -144,6 +144,12 @@ footer {
     width:0;
     background:#0f0;
 }
+.rtt-display {
+    margin-top:5px;
+    font-size:0.9em;
+    text-align:right;
+    color:#0f0;
+}
 .vfo { flex:1; display:flex; justify-content:center; }
 .vfo-knob {
     width:160px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,7 @@
             <div class="screen">
                 <div class="freq-display">14.074.000</div>
                 <div class="s-meter"><div class="bar"></div></div>
+                <div class="rtt-display">RTT: -- ms</div>
             </div>
             <div class="vfo">
                 <div class="vfo-knob"></div>
@@ -223,6 +224,9 @@ function startStatus(){
                     const pct=Math.min(100,Math.max(0,(parseInt(m[0])/255)*100));
                     document.querySelector('.s-meter .bar').style.width=pct+'%';
                 }
+            }
+            if(v.RTT!==undefined){
+                document.querySelector('.rtt-display').textContent = 'RTT: '+v.RTT+' ms';
             }
         }catch(err){}
     };


### PR DESCRIPTION
## Summary
- measure connection RTT in `ft991a_ws_server.py` with regular pings
- show RTT on the status page
- style RTT display

## Testing
- `python -m py_compile flask_server.py trx/ft991a_ws_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686a850626a883218c007e3032d92a48