### PR TITLE
Fix Flask server to always use port 8084

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ python trx/ft991a_ws_server.py --connect ws://991a.lima11.de:8084/ws/rig \
    ```bash
    python flask_server.py
    ```
-   Mit dem Parameter `--server` kann optional ein externer Dienst angesprochen werden. Die Anwendung läuft auf Port 8084 (anpassbar mit `--http-port`).
+   Mit dem Parameter `--server` kann optional ein externer Dienst angesprochen werden. Die Anwendung läuft immer auf Port 8084.
    Beim ersten Start existiert lediglich der Benutzer `admin` mit dem Passwort `admin`. Dieses Konto muss sich nach dem Login umbenennen und ein neues Passwort vergeben.
     Weitere Benutzer können sich anschließend selbst registrieren und müssen vom Administrator freigeschaltet werden, bevor sie das Gerät bedienen dürfen.
     Nur Administratoren dürfen neue Benutzer freischalten oder ihnen das Recht zur Nutzung eines TRX erteilen.

--- a/flask_server.py
+++ b/flask_server.py
@@ -662,8 +662,6 @@ def main():
                         help='Serial baud rate')
     parser.add_argument('--server', default=DEFAULT_REMOTE_SERVER,
                         help='Remote control server ws://host:port')
-    parser.add_argument('--http-port', type=int, default=8084,
-                        help='Port for the web interface')
     parser.add_argument('--secret', default=DEFAULT_SECRET,
                         help='Flask secret key')
     parser.add_argument('--input-device', type=int, default=None,
@@ -695,7 +693,8 @@ def main():
     else:
         ser = serial.Serial(SERIAL_PORT, SERIAL_BAUDRATE, timeout=1)
     try:
-        app.run(host='0.0.0.0', port=args.http_port)
+        # The web interface always runs on port 8084
+        app.run(host='0.0.0.0', port=8084)
     finally:
         if ser:
             ser.close()


### PR DESCRIPTION
## Summary
- remove the command line option for the HTTP port
- fix `flask_server.py` to always start the Flask app on port 8084
- update docs to mention the fixed port

## Testing
- `python -m py_compile flask_server.py trx/ft991a_ws_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686a88d8c9188321811c717cac43b6cc