### PR TITLE
Unify page layout with base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% block title %}{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="container {% block container_class %}{% endblock %}">
+    <header class="{% block header_class %}{% endblock %}">
+        <h1>{% block header_title %}{% endblock %}</h1>
+        {% block nav %}{% endblock %}
+    </header>
+    {% block content %}{% endblock %}
+    <footer>&copy; {{ year }} by Erik Schauer, do1ffe@darc.de</footer>
+</div>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/change_credentials.html
+++ b/templates/change_credentials.html
@@ -1,14 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Zugangsdaten &auml;ndern</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-</head>
-<body>
-<div class="container">
-    <h1>Zugangsdaten &auml;ndern</h1>
-    <p><a href="{{ url_for('logout') }}">Abmelden</a>
-    {% if role == 'admin' %}| <a href="{{ url_for('admin_users') }}">Benutzerverwaltung</a>{% endif %}</p>
+{% extends 'base.html' %}
+{% block title %}Zugangsdaten &auml;ndern{% endblock %}
+{% block header_title %}Zugangsdaten &auml;ndern{% endblock %}
+{% block nav %}<p><a href="{{ url_for('logout') }}">Abmelden</a>{% if role == 'admin' %} | <a href="{{ url_for('admin_users') }}">Benutzerverwaltung</a>{% endif %}</p>{% endblock %}
+{% block content %}
     <p>Angemeldet als {{ current }} ({{ role }})</p>
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     <form method="post">
@@ -16,7 +10,4 @@
         <label>Neues Passwort: <input type="password" name="password"></label><br>
         <button type="submit">Speichern</button>
     </form>
-    <footer>&copy; {{ year }} by Erik Schauer, do1ffe@darc.de</footer>
-</div>
-</body>
-</html>
+{% endblock %}

--- a/templates/edit_user.html
+++ b/templates/edit_user.html
@@ -1,13 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Benutzer bearbeiten</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-</head>
-<body>
-<div class="container">
-    <h1>Benutzer bearbeiten</h1>
-    <p><a href="{{ url_for('logout') }}">Abmelden</a> | <a href="{{ url_for('admin_users') }}">Zurück</a></p>
+{% extends 'base.html' %}
+{% block title %}Benutzer bearbeiten{% endblock %}
+{% block header_title %}Benutzer bearbeiten{% endblock %}
+{% block nav %}<p><a href="{{ url_for('logout') }}">Abmelden</a> | <a href="{{ url_for('admin_users') }}">Zur&uuml;ck</a></p>{% endblock %}
+{% block content %}
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     <form method="post">
         <label>Benutzername: <input type="text" name="username" value="{{ username }}"></label><br>
@@ -21,9 +16,6 @@
         <label>Freigeschaltet: <input type="checkbox" name="approved" value="1" {% if user_data.approved %}checked{% endif %}></label><br>
         <label>TRX: <input type="checkbox" name="trx" value="1" {% if user_data.trx %}checked{% endif %}></label><br>
         <button type="submit" name="action" value="update">Speichern</button>
-        <button type="submit" name="action" value="delete" onclick="return confirm('Benutzer wirklich löschen?');">Löschen</button>
+        <button type="submit" name="action" value="delete" onclick="return confirm('Benutzer wirklich l&ouml;schen?');">L&ouml;schen</button>
     </form>
-    <footer>&copy; {{ year }} by Erik Schauer, do1ffe@darc.de</footer>
-</div>
-</body>
-</html>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,16 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>FT-991A Steuerung</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-</head>
-<body>
-<div class="container radio-case ft991a">
-    <header class="rig-header">
-        <h1>FT-991A</h1>
-        <nav><a href="{{ url_for('logout') }}">Abmelden</a>{% if role == 'admin' %} | <a href="{{ url_for('admin_users') }}">Benutzerverwaltung</a>{% endif %}</nav>
-    </header>
+{% extends 'base.html' %}
+{% block title %}FT-991A Steuerung{% endblock %}
+{% block container_class %}radio-case ft991a{% endblock %}
+{% block header_class %}rig-header{% endblock %}
+{% block header_title %}FT-991A{% endblock %}
+{% block nav %}<nav><a href="{{ url_for('logout') }}">Abmelden</a>{% if role == 'admin' %} | <a href="{{ url_for('admin_users') }}">Benutzerverwaltung</a>{% endif %}</nav>{% endblock %}
+{% block content %}
     {% if role == 'admin' and unapproved_count %}
     <p class="warn">{{ unapproved_count }} Benutzer warten auf Freischaltung.</p>
     {% endif %}
@@ -156,8 +150,8 @@
             <button onclick="stopAudio()">Audio stoppen</button>
         </div>
     </main>
-    <footer>&copy; {{ year }} by Erik Schauer, do1ffe@darc.de</footer>
-</div>
+{% endblock %}
+{% block scripts %}
 <script>
 let sock;
 let processor;
@@ -263,5 +257,4 @@ document.querySelectorAll('.cmdForm').forEach(f => {
 });
 startStatus();
 </script>
-</body>
-</html>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Anmeldung</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-</head>
-<body>
-<div class="container">
-    <h1>Anmeldung</h1>
+{% extends 'base.html' %}
+{% block title %}Anmeldung{% endblock %}
+{% block header_title %}Anmeldung{% endblock %}
+{% block content %}
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     {% if message %}<p style="color:green;">{{ message }}</p>{% endif %}
     <form method="post">
@@ -15,7 +10,4 @@
         <button type="submit">Anmelden</button>
     </form>
     <p><a href="{{ url_for('register') }}">Registrieren</a></p>
-    <footer>&copy; {{ year }} by Erik Schauer, do1ffe@darc.de</footer>
-</div>
-</body>
-</html>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Registrierung</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-</head>
-<body>
-<div class="container">
-    <h1>Registrierung</h1>
+{% extends 'base.html' %}
+{% block title %}Registrierung{% endblock %}
+{% block header_title %}Registrierung{% endblock %}
+{% block content %}
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     <form method="post">
         <label>Rufzeichen: <input type="text" name="username"></label><br>
@@ -14,7 +9,4 @@
         <button type="submit">Registrieren</button>
     </form>
     <p><a href="{{ url_for('login') }}">Zur Anmeldung</a></p>
-    <footer>&copy; {{ year }} by Erik Schauer, do1ffe@darc.de</footer>
-</div>
-</body>
-</html>
+{% endblock %}

--- a/templates/userlist.html
+++ b/templates/userlist.html
@@ -1,13 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Benutzerverwaltung</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-</head>
-<body>
-<div class="container">
-    <h1>Benutzerverwaltung</h1>
-    <p><a href="{{ url_for('logout') }}">Abmelden</a> | <a href="{{ url_for('index') }}">Startseite</a></p>
+{% extends 'base.html' %}
+{% block title %}Benutzerverwaltung{% endblock %}
+{% block header_title %}Benutzerverwaltung{% endblock %}
+{% block nav %}<p><a href="{{ url_for('logout') }}">Abmelden</a> | <a href="{{ url_for('index') }}">Startseite</a></p>{% endblock %}
+{% block content %}
     <p>Angemeldet als {{ session.get('user') }} ({{ role }})</p>
     <table border="1">
         <tr><th>Benutzer</th><th>Rolle</th><th>Freigeschaltet</th><th>TRX</th><th>Aktionen</th><th>Bearbeiten</th></tr>
@@ -44,7 +39,4 @@
         {% endfor %}
     </table>
     <p><a href="{{ url_for('index') }}">Zur&uuml;ck</a></p>
-    <footer>&copy; {{ year }} by Erik Schauer, do1ffe@darc.de</footer>
-</div>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new base template to share header and footer
- update all existing HTML templates to extend the base layout
- move page-specific scripts into a dedicated `scripts` block

## Testing
- `python -m py_compile flask_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a9180f62c8321bf9aca808ecb4df8