### PR TITLE
Add encoder drop-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Die Implementierung bildet nur grundlegende Funktionen ab und kann als Grundlage
 | `MDxx;` | Betriebsart einstellen (lesen mit `MD;`) |
 | `TX;` | PTT aktivieren |
 | `RX;` | PTT deaktivieren |
+| `EU;`/`ED;` | Encoder Up/Down |
 
 Die Weboberfläche nutzt eine PTT-Schaltfläche (oder die Leertaste) zum
 Druck‑und‑Sprech-Betrieb. Beim Drücken wird einmal `TX;` gesendet und beim

--- a/flask_server.py
+++ b/flask_server.py
@@ -429,6 +429,12 @@ def command():
                 data = {'command': 'cat', 'data': f'DS{code:03d};'}
             except ValueError:
                 return ('', 204)
+        elif cmd == 'encoder':
+            if value in ('up', 'EU', 'down', 'ED'):
+                code = 'EU' if value in ('up', 'EU') else 'ED'
+                data = {'command': 'cat', 'data': f'{code};'}
+            else:
+                return ('', 204)
         elif cmd == 'mic_gain':
             try:
                 gain = int(value)
@@ -507,6 +513,12 @@ def command():
                 code = int(value)
                 data = {'command': 'cat', 'data': f'DS{code:03d};'}
             except ValueError:
+                return ('', 204)
+        elif cmd == 'encoder':
+            if value in ('up', 'EU', 'down', 'ED'):
+                code = 'EU' if value in ('up', 'EU') else 'ED'
+                data = {'command': 'cat', 'data': f'{code};'}
+            else:
                 return ('', 204)
         elif cmd == 'mic_gain':
             try:

--- a/templates/index.html
+++ b/templates/index.html
@@ -141,6 +141,16 @@
                 <button type="submit" {{ 'disabled' if controls_disabled else '' }}>MIC Gain</button>
             </form>
             <form method="post" action="{{ url_for('command') }}" class="cmdForm">
+                <label>Encoder:
+                    <select name="value" {{ 'disabled' if controls_disabled else '' }}>
+                        <option value="up">Up</option>
+                        <option value="down">Down</option>
+                    </select>
+                </label>
+                <input type="hidden" name="cmd" value="encoder">
+                <button type="submit" {{ 'disabled' if controls_disabled else '' }}>Encoder</button>
+            </form>
+            <form method="post" action="{{ url_for('command') }}" class="cmdForm">
                 <input type="hidden" name="cmd" value="get_frequency">
                 <button type="submit" {{ 'disabled' if controls_disabled else '' }}>Frequenz lesen</button>
             </form>


### PR DESCRIPTION
## Summary
- support encoder CAT command
- add encoder drop-down in control grid
- document encoder command in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686a9a52d0988321a5c764ca803aa401