### PR TITLE
Implement user presence tracking

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -467,5 +467,8 @@ document.addEventListener('keyup',e=>{
     if(e.code==='Space') stopPTT();
 });
 startStatus();
+setInterval(()=>{
+    fetch('{{ url_for('heartbeat') }}', {method:'POST'}).catch(()=>{});
+}, 5000);
 </script>
 {% endblock %}

--- a/templates/userlist.html
+++ b/templates/userlist.html
@@ -5,13 +5,14 @@
 {% block content %}
     <p>Angemeldet als {{ session.get('user') }} ({{ role }})</p>
     <table border="1">
-        <tr><th>Benutzer</th><th>Rolle</th><th>Freigeschaltet</th><th>TRX</th><th>Aktionen</th><th>Bearbeiten</th></tr>
+        <tr><th>Benutzer</th><th>Rolle</th><th>Freigeschaltet</th><th>TRX</th><th>Online</th><th>Aktionen</th><th>Bearbeiten</th></tr>
         {% for name, u in users.items() %}
         <tr>
             <td>{{ name }}</td>
             <td>{{ u.role }}</td>
             <td>{{ 'ja' if u.approved else 'nein' }}</td>
             <td>{{ 'ja' if u.trx else 'nein' }}</td>
+            <td>{{ 'ja' if name in active_users else 'nein' }}</td>
             <td>
                 <form method="post" style="display:inline">
                     <input type="hidden" name="username" value="{{ name }}">


### PR DESCRIPTION
## Summary
- add new `heartbeat` endpoint for online tracking
- track active users and show them in the admin table
- add periodic heartbeat ping from the client

## Testing
- `python -m py_compile flask_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686a9c324efc832195cc5b7e555dd3c2