### PR TITLE
Show online users with RTT

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,15 @@
     <p class="warn">{{ unapproved_count }} Benutzer warten auf Freischaltung.</p>
     {% endif %}
     <p class="user-info">Angemeldet als {{ user }} ({{ role }})</p>
+    <p class="online-users">Online:
+        {% if active_users %}
+            {% for u, r in active_users %}
+                {{ u }} ({% if r is not none %}{{ r|round(0, 'floor') }} ms{% else %}-{% endif %}){% if not loop.last %}, {% endif %}
+            {% endfor %}
+        {% else %}
+            keiner
+        {% endif %}
+    </p>
     <main>
         <div class="front-panel">
             <div class="screen">
@@ -467,8 +476,16 @@ document.addEventListener('keyup',e=>{
     if(e.code==='Space') stopPTT();
 });
 startStatus();
+let lastRtt = null;
 setInterval(()=>{
-    fetch('{{ url_for('heartbeat') }}', {method:'POST'}).catch(()=>{});
+    const start = performance.now();
+    fetch('{{ url_for('heartbeat') }}', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({rtt:lastRtt})
+    }).then(()=>{
+        lastRtt = Math.round(performance.now() - start);
+    }).catch(()=>{});
 }, 5000);
 </script>
 {% endblock %}

--- a/templates/userlist.html
+++ b/templates/userlist.html
@@ -5,14 +5,13 @@
 {% block content %}
     <p>Angemeldet als {{ session.get('user') }} ({{ role }})</p>
     <table border="1">
-        <tr><th>Benutzer</th><th>Rolle</th><th>Freigeschaltet</th><th>TRX</th><th>Online</th><th>Aktionen</th><th>Bearbeiten</th></tr>
+        <tr><th>Benutzer</th><th>Rolle</th><th>Freigeschaltet</th><th>TRX</th><th>Aktionen</th><th>Bearbeiten</th></tr>
         {% for name, u in users.items() %}
         <tr>
             <td>{{ name }}</td>
             <td>{{ u.role }}</td>
             <td>{{ 'ja' if u.approved else 'nein' }}</td>
             <td>{{ 'ja' if u.trx else 'nein' }}</td>
-            <td>{{ 'ja' if name in active_users else 'nein' }}</td>
             <td>
                 <form method="post" style="display:inline">
                     <input type="hidden" name="username" value="{{ name }}">


### PR DESCRIPTION
## Summary
- keep RTT per user on heartbeat
- list active users with RTT values on the index page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686a9df94e74832189ef6c45c1d9e5ce