### PR TITLE
Update heartbeat to show active users

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -485,6 +485,16 @@ setInterval(()=>{
         body: JSON.stringify({rtt:lastRtt})
     }).then(()=>{
         lastRtt = Math.round(performance.now() - start);
+        return fetch('{{ url_for('active_users_api') }}');
+    }).then(r=>r.json()).then(users=>{
+        const p=document.querySelector('.online-users');
+        if(p){
+            if(users.length){
+                p.textContent='Online: '+users.map(u=>`${u[0]} (${u[1]!==null?Math.floor(u[1])+' ms':'-'})`).join(', ');
+            }else{
+                p.textContent='Online: keiner';
+            }
+        }
     }).catch(()=>{});
 }, 5000);
 </script>


### PR DESCRIPTION
## Summary
- add an API endpoint `/active_users` providing the list of online users
- update the JavaScript on the main page to refresh the list dynamically

## Testing
- `python -m py_compile flask_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686aa0cb5cfc83219c27c0258258300a