### PR TITLE
Fix active user display and restrict API

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -201,6 +201,8 @@ def index():
             else:
                 del ACTIVE_USERS[u]
                 USER_RTT.pop(u, None)
+        if user not in [u for u, _ in active_users]:
+            active_users.append((user, USER_RTT.get(user)))
     return render_template(
         'index.html', rigs=rigs, selected_rig=selected,
         operator=operator, operator_status=operator_status,
@@ -418,6 +420,8 @@ def heartbeat():
 def active_users_api():
     if not session.get('logged_in'):
         return ('', 401)
+    if session.get('role') != 'admin':
+        return ('', 403)
     now = time.time()
     with ACTIVE_LOCK:
         users = []


### PR DESCRIPTION
## Summary
- always include current user in active user list
- restrict `/active_users` endpoint to admins only

## Testing
- `curl -b cookies.txt -X POST -H 'Content-Type: application/json' -d '{"rtt": 88}' http://127.0.0.1:8084/heartbeat -w '\n%{http_code}\n'`
- `curl -b cookies.txt http://127.0.0.1:8084/active_users`

------
https://chatgpt.com/codex/tasks/task_e_686aa7f1098c8321bfbfaef93f953b10