### PR TITLE
Fix RTT update for online user list

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -482,19 +482,21 @@ let lastRtt = null;
 async function ping(){
     const start = performance.now();
     try{
-        await fetch('{{ url_for('heartbeat') }}', {
+        const res = await fetch('{{ url_for('heartbeat') }}', {
             method:'POST',
             credentials:'same-origin',
             headers:{'Content-Type':'application/json'},
             body: JSON.stringify({rtt:lastRtt})
         });
         lastRtt = Math.round(performance.now() - start);
-        await fetch('{{ url_for('heartbeat') }}', {
-            method:'POST',
-            credentials:'same-origin',
-            headers:{'Content-Type':'application/json'},
-            body: JSON.stringify({rtt:lastRtt})
-        });
+        if(res.ok){
+            await fetch('{{ url_for('heartbeat') }}', {
+                method:'POST',
+                credentials:'same-origin',
+                headers:{'Content-Type':'application/json'},
+                body: JSON.stringify({rtt:lastRtt})
+            });
+        }
         const r = await fetch('{{ url_for('active_users_api') }}', {credentials:'same-origin'});
         const users = await r.json();
         const p=document.querySelector('.online-users');


### PR DESCRIPTION
## Summary
- ensure heartbeat RTT value is sent and processed reliably

## Testing
- `python -m py_compile flask_server.py trx/ft991a_ws_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686aae00181c8321bf5e5d53415a6c83