### PR TITLE
Add wss support for trx client

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
 ### Server am Funkgerät (Windows)
 
 1. Auf dem Windows‑Rechner mit angeschlossenem FT‑991A den Steuerungsdienst starten und
-   eine Verbindung zum Flask‑Server aufbauen. Der TRX verbindet sich dabei immer automatisch mit
-   `991a.lima11.de:8084`. Melden Sie sich mit Ihren Benutzerdaten an:
+   eine Verbindung zum Flask‑Server aufbauen. Der TRX verbindet sich dabei immer automatisch über
+   `wss://991a.lima11.de:8084/ws/rig` (anpassbar mit `--server`). Melden Sie sich mit Ihren Benutzerdaten an:
   ```bash
   python trx/ft991a_ws_server.py --serial-port COM3 \
-      --callsign MYCALL --username MYCALL --password secret
+      --callsign MYCALL --username MYCALL --password secret \
+      --server wss://991a.lima11.de:8084/ws/rig
   ```
    Der COM‑Port ist ggf. anzupassen. Verbinden sich mehrere Stationen, wählen Sie in der Weboberfläche anhand des Rufzeichens das gewünschte Gerät aus. Jeder TRX muss daher mit einem eindeutigen Rufzeichen angemeldet werden.
 

--- a/trx/ft991a_ws_server.py
+++ b/trx/ft991a_ws_server.py
@@ -9,7 +9,7 @@ import os
 
 DEFAULT_SERIAL_PORT = 'COM3'
 DEFAULT_BAUDRATE = 9600
-DEFAULT_CONNECT_URI = 'ws://991a.lima11.de:8084/ws/rig'
+DEFAULT_CONNECT_URI = 'wss://991a.lima11.de:8084/ws/rig'
 DEFAULT_CALLSIGN = 'FT-991A'
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -178,6 +178,8 @@ async def main():
                         help='Serial baud rate')
     parser.add_argument('--callsign', default=DEFAULT_CALLSIGN,
                         help='Station callsign to announce')
+    parser.add_argument('--server', default=DEFAULT_CONNECT_URI,
+                        help='Flask server ws(s)://host:port/ws/rig')
     parser.add_argument('--username', default=None,
                         help='Username for login')
     parser.add_argument('--password', default=None,
@@ -198,7 +200,7 @@ async def main():
             handshake.update({'username': args.username,
                               'password': args.password,
                               'mode': 'trx'})
-        await client_loop(DEFAULT_CONNECT_URI, handshake)
+        await client_loop(args.server, handshake)
     finally:
         if ser:
             ser.close()


### PR DESCRIPTION
## Summary
- support secure WebSocket connections for `ft991a_ws_server.py`
- document connection to `wss://991a.lima11.de:8084/ws/rig` and `--server` option

## Testing
- `python -m py_compile flask_server.py trx/ft991a_ws_server.py`


------
https://chatgpt.com/codex/tasks/task_e_686ab7c508108321a74cd42b2ebb3ff0