### PR TITLE
Allow custom usernames for admin-created accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Funkgeräts selbst und wird daher immer im TRX-Modus betrieben.
    Mit dem Parameter `--server` kann optional ein externer Dienst angesprochen werden. Die Anwendung läuft immer auf Port 8084.
    Beim ersten Start existiert lediglich der Benutzer `admin` mit dem Passwort `admin`. Dieses Konto muss sich nach dem Login umbenennen und ein neues Passwort vergeben.
     Weitere Benutzer können sich anschließend selbst registrieren und müssen vom Administrator freigeschaltet werden, bevor sie das Gerät bedienen dürfen.
-    Nur Administratoren dürfen neue Benutzer freischalten oder ihnen das Recht zur Nutzung eines TRX erteilen.
+    Nur Administratoren dürfen neue Benutzer freischalten oder ihnen das Recht zur Nutzung eines TRX erteilen. Administratoren können auch direkt neue Konten anlegen und dabei beliebige Benutzernamen verwenden.
    Über `--list-devices` lassen sich verfügbare Audio‑Geräte anzeigen. Mit
    `--input-device` und `--output-device` kann anschließend die gewünschte
    Geräte‑Nummer gewählt werden.

--- a/templates/create_user.html
+++ b/templates/create_user.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Benutzer hinzufügen{% endblock %}
+{% block header_title %}Benutzer hinzufügen{% endblock %}
+{% block nav %}<p><a href="{{ url_for('logout') }}">Abmelden</a> | <a href="{{ url_for('admin_users') }}">Zurück</a></p>{% endblock %}
+{% block content %}
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="post">
+        <label>Benutzername: <input type="text" name="username"></label><br>
+        <label>Passwort: <input type="password" name="password"></label><br>
+        <label>Rolle:
+            <select name="role">
+                <option value="operator" {% if user_data.role == 'operator' %}selected{% endif %}>Operator</option>
+                <option value="admin" {% if user_data.role == 'admin' %}selected{% endif %}>Admin</option>
+            </select>
+        </label><br>
+        <label>Freigeschaltet: <input type="checkbox" name="approved" value="1" {% if user_data.approved %}checked{% endif %}></label><br>
+        <label>TRX: <input type="checkbox" name="trx" value="1" {% if user_data.trx %}checked{% endif %}></label><br>
+        <button type="submit">Anlegen</button>
+    </form>
+{% endblock %}

--- a/templates/userlist.html
+++ b/templates/userlist.html
@@ -4,6 +4,7 @@
 {% block nav %}<p><a href="{{ url_for('logout') }}">Abmelden</a> | <a href="{{ url_for('index') }}">Startseite</a></p>{% endblock %}
 {% block content %}
     <p>Angemeldet als {{ session.get('user') }} ({{ role }})</p>
+    <p><a href="{{ url_for('admin_create_user') }}">Neuen Benutzer anlegen</a></p>
     <table border="1">
         <tr><th>Benutzer</th><th>Rolle</th><th>Freigeschaltet</th><th>TRX</th><th>Aktionen</th><th>Bearbeiten</th></tr>
         {% for name, u in users.items() %}


### PR DESCRIPTION
## Summary
- add `/admin/create_user` endpoint to allow admins to create accounts directly
- remove callsign restriction from admin edit operations and update change credentials logic
- add link to the new form in the user list
- document in README that admins may create accounts with arbitrary names

## Testing
- `python -m py_compile flask_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abf81dc10832188e17e0009929d1e