### PR TITLE
Implement rig-specific audio streaming with mute option

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -357,6 +357,7 @@
         <div class="audio-controls">
             <button onclick="startAudio()">Audio starten</button>
             <button onclick="stopAudio()">Audio stoppen</button>
+            <label><input type="checkbox" id="mute-audio" onchange="toggleMute()">Mute</label>
         </div>
     </main>
 {% endblock %}
@@ -366,6 +367,8 @@ const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
 let sock;
 let processor;
 let audioRetry;
+let muted=false;
+function toggleMute(){ muted = document.getElementById('mute-audio').checked; }
 function startAudio(){
     function connect(){
         sock = new WebSocket(wsProto + '://' + location.host + '/ws/audio');
@@ -391,17 +394,19 @@ function startAudio(){
             if(sock.readyState===WebSocket.OPEN) sock.send(buf);
         };
         sock.onmessage=event=>{
-            const view=new DataView(event.data);
-            const floats=new Float32Array(view.byteLength/2);
-            for(let i=0;i<floats.length;i++){
-                floats[i]=view.getInt16(i*2,true)/0x8000;
+            if(!muted){
+                const view=new DataView(event.data);
+                const floats=new Float32Array(view.byteLength/2);
+                for(let i=0;i<floats.length;i++){
+                    floats[i]=view.getInt16(i*2,true)/0x8000;
+                }
+                const buffer=audioCtx.createBuffer(1,floats.length,16000);
+                buffer.getChannelData(0).set(floats);
+                const bs=audioCtx.createBufferSource();
+                bs.buffer=buffer;
+                bs.connect(audioCtx.destination);
+                bs.start();
             }
-            const buffer=audioCtx.createBuffer(1,floats.length,16000);
-            buffer.getChannelData(0).set(floats);
-            const bs=audioCtx.createBufferSource();
-            bs.buffer=buffer;
-            bs.connect(audioCtx.destination);
-            bs.start();
         };
         });
     }

--- a/trx/trx_gui.py
+++ b/trx/trx_gui.py
@@ -188,7 +188,18 @@ class App:
         async def run_client():
             await trx.client_loop(server_uri, handshake)
 
-        await asyncio.gather(users_loop(), run_client())
+        async def run_audio():
+            audio_handshake = {
+                'callsign': cfg['callsign'],
+                'username': cfg['username'],
+                'password': cfg['password'],
+                'mode': 'trx_audio'
+            }
+            await trx.audio_loop(server_uri.rsplit('/',1)[0]+'/rig_audio',
+                                audio_handshake,
+                                cfg['input_device'],
+                                cfg['output_device'])
+        await asyncio.gather(users_loop(), run_client(), run_audio())
 
 
 def main():


### PR DESCRIPTION
## Summary
- route audio from user directly to selected rig via new `/ws/rig_audio`
- broadcast rig audio to all listeners and forward user audio to rig
- add mute option in the web UI
- extend transceiver service with audio websocket support

## Testing
- `python -m py_compile flask_server.py trx/ft991a_ws_server.py trx/trx_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_686ad5601d3c83219e91294ee64f1df7