### PR TITLE
Restrict audio transmission to active operator

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -831,10 +831,16 @@ def audio(ws):
                 msg = ws.receive()
                 if msg is None:
                     break
-                try:
-                    rig_ws.send(msg)
-                except Exception:
-                    break
+                allow = False
+                user = session.get('user')
+                if rig and user:
+                    with OPERATOR_LOCK:
+                        allow = OPERATORS.get(rig) == user
+                if allow:
+                    try:
+                        rig_ws.send(msg)
+                    except Exception:
+                        break
         finally:
             with AUDIO_CLIENTS_LOCK:
                 AUDIO_CLIENTS.get(rig, set()).discard(ws)

--- a/templates/index.html
+++ b/templates/index.html
@@ -364,6 +364,7 @@
 {% block scripts %}
 <script>
 const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
+const isOperator = {{ 'true' if operator==user else 'false' }};
 let sock;
 let processor;
 let audioRetry;
@@ -377,22 +378,25 @@ function startAudio(){
             if(processor){ processor.disconnect(); processor=null; }
             audioRetry = setTimeout(connect, 1000);
         };
-        navigator.mediaDevices.getUserMedia({audio:true}).then(stream=>{
-            const audioCtx = new (window.AudioContext || window.webkitAudioContext)({sampleRate:16000});
-            const source = audioCtx.createMediaStreamSource(stream);
-            processor = audioCtx.createScriptProcessor(1024,1,1);
-            source.connect(processor);
-            processor.connect(audioCtx.destination);
-        processor.onaudioprocess = e=>{
-            const input=e.inputBuffer.getChannelData(0);
-            const buf=new ArrayBuffer(input.length*2);
-            const view=new DataView(buf);
-            for(let i=0;i<input.length;i++){
-                let s=Math.max(-1,Math.min(1,input[i]));
-                view.setInt16(i*2,s*0x7FFF,true);
-            }
-            if(sock.readyState===WebSocket.OPEN) sock.send(buf);
-        };
+        const audioCtx = new (window.AudioContext || window.webkitAudioContext)({sampleRate:16000});
+        if(isOperator){
+            navigator.mediaDevices.getUserMedia({audio:true}).then(stream=>{ 
+                const source = audioCtx.createMediaStreamSource(stream);
+                processor = audioCtx.createScriptProcessor(1024,1,1);
+                source.connect(processor);
+                processor.connect(audioCtx.destination);
+                processor.onaudioprocess = e=>{
+                    const input=e.inputBuffer.getChannelData(0);
+                    const buf=new ArrayBuffer(input.length*2);
+                    const view=new DataView(buf);
+                    for(let i=0;i<input.length;i++){
+                        let s=Math.max(-1,Math.min(1,input[i]));
+                        view.setInt16(i*2,s*0x7FFF,true);
+                    }
+                    if(sock.readyState===WebSocket.OPEN) sock.send(buf);
+                };
+            });
+        }
         sock.onmessage=event=>{
             if(!muted){
                 const view=new DataView(event.data);
@@ -408,7 +412,6 @@ function startAudio(){
                 bs.start();
             }
         };
-        });
     }
     connect();
 }


### PR DESCRIPTION
## Summary
- ensure only the active operator can forward audio to a TRX
- skip microphone capture on the client unless the user is the operator

## Testing
- `python -m py_compile flask_server.py trx/ft991a_ws_server.py trx/trx_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_686ad74661608321a5baf1264734a81d