### PR TITLE
Add route to fetch CAT answers

### DIFF
--- a/templates/answers.html
+++ b/templates/answers.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}CAT Antworten{% endblock %}
+{% block header_title %}CAT Antworten{% endblock %}
+{% block nav %}<nav><a href="{{ url_for('index') }}">Zurück</a> | <a href="{{ url_for('logout') }}">Abmelden</a></nav>{% endblock %}
+{% block content %}
+    <h2>CAT Antworten</h2>
+    {% if answers %}
+    <table>
+        <tr><th>Kommando</th><th>Antwort</th></tr>
+        {% for cmd, ans in answers.items() %}
+        <tr><td>{{ cmd }}</td><td>{{ ans }}</td></tr>
+        {% endfor %}
+    </table>
+    {% else %}
+    <p>Keine Daten vorhanden.</p>
+    {% endif %}
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 {% block container_class %}radio-case ft991a{% endblock %}
 {% block header_class %}rig-header{% endblock %}
 {% block header_title %}FT-991A{% endblock %}
-{% block nav %}<nav><a href="{{ url_for('logout') }}">Abmelden</a>{% if role == 'admin' %} | <a href="{{ url_for('admin_users') }}">Benutzerverwaltung</a>{% endif %}</nav>{% endblock %}
+{% block nav %}<nav><a href="{{ url_for('logout') }}">Abmelden</a>{% if role == 'admin' %} | <a href="{{ url_for('admin_users') }}">Benutzerverwaltung</a> | <a href="{{ url_for('show_answers') }}">CAT Antworten</a>{% endif %}</nav>{% endblock %}
 {% block content %}
     {% if role == 'admin' and unapproved_count %}
     <p class="warn">{{ unapproved_count }} Benutzer warten auf Freischaltung.</p>


### PR DESCRIPTION
## Summary
- load answer-capable CAT commands from `cat_commands_summary.md`
- add helper to fetch answers from the rig and store them as `cat_answers.json`
- add `/answers` page to display stored command answers
- add `/fetch_answers` endpoint for admins to update the file
- link to the new page from the main navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aeeeeebbc8321a7b1d17c1870c7a0