### PR TITLE
Add baudrate selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,16 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
    eine Verbindung zum Flask‑Server aufbauen. Der TRX verbindet sich dabei immer automatisch über
    `wss://991a.lima11.de:8084/ws/rig` (anpassbar mit `--server`). Melden Sie sich mit Ihren Benutzerdaten an:
  ```bash
- python trx/ft991a_ws_server.py --serial-port COM3 \
-      --callsign MYCALL --username MYCALL --password secret \
-      --server wss://991a.lima11.de:8084/ws/rig
+python trx/ft991a_ws_server.py --serial-port COM3 \
+     --baudrate 9600 \
+     --callsign MYCALL --username MYCALL --password secret \
+     --server wss://991a.lima11.de:8084/ws/rig
  ```
- Alternativ kann `python trx/trx_gui.py` verwendet werden. Die Oberfläche
- speichert Zugangsdaten sowie Audio- und COM-Port-Auswahl und startet den
- Dienst nach Klick auf **START**. In einem kleinen Fenster werden dabei nur
- die Nutzer angezeigt, die gerade diesen TRX verwenden.
-  Der COM‑Port ist ggf. anzupassen. Verbinden sich mehrere Stationen, wählen Sie in der Weboberfläche anhand des Rufzeichens das gewünschte Gerät aus. Jeder TRX muss daher mit einem eindeutigen Rufzeichen angemeldet werden.
+Alternativ kann `python trx/trx_gui.py` verwendet werden. Die Oberfläche
+speichert Zugangsdaten sowie Audio-, COM-Port- und Baudrate-Auswahl und startet den
+Dienst nach Klick auf **START**. In einem kleinen Fenster werden dabei nur
+die Nutzer angezeigt, die gerade diesen TRX verwenden.
+ Der COM‑Port und die Baudrate sind ggf. anzupassen. Verbinden sich mehrere Stationen, wählen Sie in der Weboberfläche anhand des Rufzeichens das gewünschte Gerät aus. Jeder TRX muss daher mit einem eindeutigen Rufzeichen angemeldet werden.
 
 ### Nutzung als Operator
 

--- a/trx/trx_gui.py
+++ b/trx/trx_gui.py
@@ -71,6 +71,13 @@ class App:
         self.port_combo.grid(row=row, column=1, sticky='w')
         row += 1
 
+        ttk.Label(frame, text='Baudrate').grid(row=row, column=0, sticky='e')
+        self.baud_var = tk.StringVar(value=str(cfg.get('baudrate', trx.DEFAULT_BAUDRATE)))
+        baudrates = ["9600", "19200", "38400", "57600", "115200"]
+        self.baud_combo = ttk.Combobox(frame, textvariable=self.baud_var, values=baudrates, width=15)
+        self.baud_combo.grid(row=row, column=1, sticky='w')
+        row += 1
+
         ttk.Label(frame, text='Input-Audio').grid(row=row, column=0, sticky='e')
         self.in_var = tk.IntVar(value=cfg.get('input_device', -1))
         ttk.Label(frame, textvariable=tk.StringVar()).grid(row=row, column=2)
@@ -119,6 +126,7 @@ class App:
             self.user_var.get().strip(),
             self.pw_var.get(),
             self.port_var.get().strip(),
+            self.baud_combo.get(),
             self.input_combo.get(),
             self.output_combo.get(),
         ])
@@ -133,6 +141,7 @@ class App:
             'username': self.user_var.get().strip(),
             'password': self.pw_var.get(),
             'serial_port': self.port_var.get().strip(),
+            'baudrate': int(self.baud_combo.get()),
             'input_device': int(self.input_combo.get().split(':')[0]),
             'output_device': int(self.output_combo.get().split(':')[0]),
         }
@@ -177,7 +186,8 @@ class App:
     async def async_main(self, cfg):
         trx.CALLSIGN = cfg['callsign']
         try:
-            trx.ser = serial.Serial(cfg['serial_port'], trx.DEFAULT_BAUDRATE, timeout=1)
+            baud = cfg.get('baudrate', trx.DEFAULT_BAUDRATE)
+            trx.ser = serial.Serial(cfg['serial_port'], baud, timeout=1)
         except SerialException:
             self.queue.put(('users', ['Kein TRX verbunden']))
             return


### PR DESCRIPTION
## Summary
- allow specifying the serial baud rate in `trx_gui.py`
- mention `--baudrate` and GUI support in the README

## Testing
- `python -m py_compile flask_server.py trx/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bab3615d083218ece4d27c8a05a2b