### PR TITLE
Add dummy radio fallback

### DIFF
--- a/trx/trx_gui.py
+++ b/trx/trx_gui.py
@@ -224,8 +224,8 @@ class App:
             baud = cfg.get('baudrate', trx.DEFAULT_BAUDRATE)
             trx.ser = serial.Serial(cfg['serial_port'], baud, timeout=1)
         except SerialException:
-            self.queue.put(('users', ['Kein TRX verbunden']))
-            return
+            self.queue.put(('users', ['Dummy-TRX aktiv']))
+            trx.ser = trx.DummySerial()
         handshake = {
             'callsign': cfg['callsign'],
             'username': cfg['username'],


### PR DESCRIPTION
## Summary
- introduce `DummySerial` as a placeholder device
- use dummy serial when no transceiver is connected
- show message `Dummy-TRX aktiv` in the GUI
- simulate a simple transceiver so CAT commands return usable data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d88637678832199cef5c455d12c3b