### PR TITLE
Fix ws default and GUI audio names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Dieses Projekt stellt eine einfach zu bedienende Weboberfläche zur Fernsteuerun
 
 1. Auf dem Windows‑Rechner mit angeschlossenem FT‑991A den Steuerungsdienst starten und
    eine Verbindung zum Flask‑Server aufbauen. Der TRX verbindet sich dabei immer automatisch über
-   `wss://991a.lima11.de:8084/ws/rig` (anpassbar mit `--server`). Melden Sie sich mit Ihren Benutzerdaten an:
+   `ws://991a.lima11.de:8084/ws/rig` (anpassbar mit `--server`). Melden Sie sich mit Ihren Benutzerdaten an:
  ```bash
 python trx/ft991a_ws_server.py --serial-port COM3 \
      --baudrate 9600 \
      --callsign MYCALL --username MYCALL --password secret \
-     --server wss://991a.lima11.de:8084/ws/rig
+     --server ws://991a.lima11.de:8084/ws/rig
  ```
 Alternativ kann `python trx/trx_gui.py` verwendet werden. Die Oberfläche
 speichert Zugangsdaten sowie Audio-, COM-Port- und Baudrate-Auswahl und startet den

--- a/templates/index.html
+++ b/templates/index.html
@@ -363,7 +363,7 @@
 {% endblock %}
 {% block scripts %}
 <script>
-const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
+const wsProto = 'ws';
 const isOperator = {{ 'true' if operator==user else 'false' }};
 let sock;
 let processor;

--- a/trx/ft991a_ws_server.py
+++ b/trx/ft991a_ws_server.py
@@ -14,7 +14,7 @@ except ImportError:  # pragma: no cover
 
 DEFAULT_SERIAL_PORT = 'COM3'
 DEFAULT_BAUDRATE = 9600
-DEFAULT_CONNECT_URI = 'wss://991a.lima11.de:8084/ws/rig'
+DEFAULT_CONNECT_URI = 'ws://991a.lima11.de:8084/ws/rig'
 DEFAULT_CALLSIGN = 'FT-991A'
 DEFAULT_AUDIO_URI = DEFAULT_CONNECT_URI.rsplit('/', 1)[0] + '/rig_audio'
 AUDIO_RATE = 16000

--- a/trx/trx_gui.py
+++ b/trx/trx_gui.py
@@ -43,8 +43,9 @@ def load_config():
 
 
 def save_config(cfg):
+    """Konfiguration UTF-8 speichern."""
     with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
-        json.dump(cfg, f)
+        json.dump(cfg, f, ensure_ascii=False, indent=2)
 
 
 class App:
@@ -115,21 +116,26 @@ class App:
         output_devices = []
         for i in range(p.get_device_count()):
             info = p.get_device_info_by_index(i)
-            entry = f"{i}: {info['name']}"
+            name = info['name']
+            if isinstance(name, bytes):
+                name = name.decode('utf-8', errors='replace')
+            entry = f"{i}: {name}"
             if info.get('maxInputChannels', 0) > 0:
                 input_devices.append(entry)
             if info.get('maxOutputChannels', 0) > 0:
                 output_devices.append(entry)
         p.terminate()
 
-        self.input_combo = ttk.Combobox(frame, values=input_devices, width=40)
+        input_width = max((len(d) for d in input_devices), default=40)
+        self.input_combo = ttk.Combobox(frame, values=input_devices, width=input_width)
         self.input_combo.grid(row=input_row, column=1, sticky='w')
         for pos, dev in enumerate(input_devices):
             if int(dev.split(':')[0]) == self.in_var.get():
                 self.input_combo.current(pos)
                 break
 
-        self.output_combo = ttk.Combobox(frame, values=output_devices, width=40)
+        output_width = max((len(d) for d in output_devices), default=40)
+        self.output_combo = ttk.Combobox(frame, values=output_devices, width=output_width)
         self.output_combo.grid(row=output_row, column=1, sticky='w')
         for pos, dev in enumerate(output_devices):
             if int(dev.split(':')[0]) == self.out_var.get():


### PR DESCRIPTION
## Summary
- use `ws://` instead of `wss://` as default connection
- ensure audio configuration is saved as UTF‑8
- allow audio device dropdowns to adapt to longest text
- decode audio device names safely

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d8fa2afbc83219187c04dadcb2ccf