### PR TITLE
Fix serial memory scan error

### DIFF
--- a/trx/ft991a_ws_server.py
+++ b/trx/ft991a_ws_server.py
@@ -193,7 +193,12 @@ async def read_memory_channels():
         async with ser_lock:
             for i in range(125):
                 ser.write(f'MR{i:03d};'.encode('ascii'))
-                reply = ser.readline().decode('ascii', errors='ignore').strip()
+                try:
+                    raw = ser.readline()
+                except (TypeError, SerialException):
+                    logger.warning('Serial read failed during memory scan')
+                    break
+                reply = raw.decode('ascii', errors='ignore').strip()
                 if reply and any(ch != '0' for ch in reply):
                     memories.append(i)
     except Exception:


### PR DESCRIPTION
## Summary
- handle failing serial reads in `read_memory_channels`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686fc82daa1c8321a4563c9948ad77e2