### PR TITLE
Implement automatische Baudratenerkennung

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,8 @@ Bei den Parametern `--server` und `--audio-server` darf auch eine HTTP(S)-Adress
 angegeben werden. Das Programm wandelt diese automatisch in das passende
 WebSocket-Schema (`ws://` bzw. `wss://`) um.
 Alternativ kann `python trx/trx_gui.py` verwendet werden. Die Oberfläche
-speichert Zugangsdaten sowie Audio-, COM-Port- und Baudrate-Auswahl und startet den
-Dienst nach Klick auf **START**. In einem kleinen Fenster werden dabei nur
-die Nutzer angezeigt, die gerade diesen TRX verwenden.
- Der COM‑Port und die Baudrate sind ggf. anzupassen. Verbinden sich mehrere Stationen, wählen Sie in der Weboberfläche anhand des Rufzeichens das gewünschte Gerät aus. Jeder TRX muss daher mit einem eindeutigen Rufzeichen angemeldet werden.
+speichert Zugangsdaten sowie Audio-, COM-Port- und Baudrate-Auswahl und startet den Dienst nach Klick auf **START**. In einem kleinen Fenster werden dabei nur
+die Nutzer angezeigt, die gerade diesen TRX verwenden. Der COM‑Port muss gegebenenfalls angepasst werden. Die Baudrate wird automatisch erkannt, sofern das Funkgerät antwortet. Verbinden sich mehrere Stationen, wählen Sie in der Weboberfläche anhand des Rufzeichens das gewünschte Gerät aus. Jeder TRX muss daher mit einem eindeutigen Rufzeichen angemeldet werden.
 
 ### Nutzung als Operator
 

--- a/trx/trx_gui.py
+++ b/trx/trx_gui.py
@@ -239,7 +239,7 @@ class App:
         trx.CALLSIGN = cfg['callsign']
         try:
             baud = cfg.get('baudrate', trx.DEFAULT_BAUDRATE)
-            trx.ser = serial.Serial(cfg['serial_port'], baud, timeout=1)
+            trx.ser = trx.open_serial_autodetect(cfg['serial_port'], baud)
         except SerialException:
             self.queue.put(('users', ['Dummy-TRX aktiv']))
             trx.ser = trx.DummySerial()


### PR DESCRIPTION
## Summary
- ergaenze Liste ueblicher Baudraten
- pruefe beim Start automatisch, welche Baudrate am TRX funktioniert
- passe GUI sowie README entsprechend an

## Testing
- `pip install -r requirements.txt` *(fail: subprocess-exited-with-error)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686fca78feb48321a40f9a46e215d467