### PR TITLE
Fix memory scan error handling

### DIFF
--- a/trx/ft991a_ws_server.py
+++ b/trx/ft991a_ws_server.py
@@ -222,7 +222,9 @@ async def read_memory_channels():
                 ser.write(f'MR{i:03d};'.encode('ascii'))
                 try:
                     raw = ser.readline()
-                except (TypeError, SerialException):
+                except (AttributeError, TypeError, SerialException):
+                    # PySerial wirft mitunter AttributeError, wenn die
+                    # Schnittstelle unerwartet geschlossen wurde.
                     logger.warning('Serial read failed during memory scan')
                     break
                 reply = raw.decode('ascii', errors='ignore').strip()


### PR DESCRIPTION
## Summary
- avoid crash when reading memory channels if the serial port is unexpectedly closed

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686fcf5cada8832184ec23cecc59cc18