### PR TITLE
Handle pyserial error when scanning memories

### DIFF
--- a/trx/ft991a_ws_server.py
+++ b/trx/ft991a_ws_server.py
@@ -219,7 +219,13 @@ async def read_memory_channels():
     try:
         async with ser_lock:
             for i in range(125):
-                ser.write(f'MR{i:03d};'.encode('ascii'))
+                try:
+                    ser.write(f'MR{i:03d};'.encode('ascii'))
+                except OSError:
+                    # Unter Windows kann PySerial einen OSError liefern, wenn
+                    # der Handle ungueltig wurde.
+                    logger.warning('Serial write failed during memory scan')
+                    break
                 try:
                     raw = ser.readline()
                 except (AttributeError, TypeError, SerialException):


### PR DESCRIPTION
## Summary
- catch `OSError` during memory channel scan

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: building wheel for pyaudio)*

------
https://chatgpt.com/codex/tasks/task_e_686fd0eb3dcc83219b9e0bd74e753b99