### PR TITLE
Enable TRX login

### DIFF
--- a/users.json
+++ b/users.json
@@ -3,6 +3,7 @@
     "password": "scrypt:32768:8:1$TcoiTY1bQX5Custw$cbf8852fd0b17a1f48e61b2eeb1f9888bf20c10594e0ca9c3cf94920e5fc711ad5f3775f396ab33f7a9096d3c314af828ce603ebb9a48efc064a2a65030a1632",
     "role": "admin",
     "approved": true,
-    "needs_change": true
+    "needs_change": true,
+    "trx": true
   }
 }


### PR DESCRIPTION
## Summary
- grant the default admin TRX permissions so the service can connect

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- manual run of `flask_server.py` and `ft991a_ws_server.py`
- verified `/ws/rig_list` and `/ws/status` via `websockets.connect`

------
https://chatgpt.com/codex/tasks/task_e_687a40f3a7b48321a3a6fb824b738b78