### PR TITLE
Implement WebSocket traffic log

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 {% block container_class %}radio-case ft991a{% endblock %}
 {% block header_class %}rig-header{% endblock %}
 {% block header_title %}FT-991A{% endblock %}
-{% block nav %}<nav><a href="{{ url_for('logout') }}">Abmelden</a>{% if role == 'admin' %} | <a href="{{ url_for('admin_users') }}">Benutzerverwaltung</a> | <a href="{{ url_for('show_answers') }}">CAT Antworten</a>{% endif %}</nav>{% endblock %}
+{% block nav %}<nav><a href="{{ url_for('logout') }}">Abmelden</a>{% if role == 'admin' %} | <a href="{{ url_for('admin_users') }}">Benutzerverwaltung</a> | <a href="{{ url_for('show_answers') }}">CAT Antworten</a> | <a href="{{ url_for('show_log') }}">Log</a>{% endif %}</nav>{% endblock %}
 {% block content %}
     {% if role == 'admin' and unapproved_count %}
     <p class="warn">{{ unapproved_count }} Benutzer warten auf Freischaltung.</p>

--- a/templates/log.html
+++ b/templates/log.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}WebSocket Log{% endblock %}
+{% block header_title %}WebSocket Log{% endblock %}
+{% block nav %}<nav><a href="{{ url_for('index') }}">Zurück</a> | <a href="{{ url_for('logout') }}">Abmelden</a></nav>{% endblock %}
+{% block content %}
+<h2>Letzte WebSocket Meldungen</h2>
+<pre>
+{% for line in entries %}
+{{ line }}
+{% endfor %}
+</pre>
+{% endblock %}


### PR DESCRIPTION
## Summary
- record every WebSocket event in a ring buffer
- add `/log` route to view collected messages
- link log page from the main view for admins

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a4cd62f8883218e41eae78abf74a5