### PR TITLE
Improve 991A client resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ python trx/ft991a_ws_server.py --serial-port COM3 \
     --baudrate 9600 \
     --callsign MYCALL --username MYCALL --password secret \
     --server wss://991a.lima11.de/ws/rig
-``` 
+```
+Fehlt eine passende Soundkarte, kann die Audioubertragung mit `--no-audio`
+deaktiviert werden:
+```bash
+python trx/ft991a_ws_server.py --serial-port COM3 \
+    --callsign MYCALL --username MYCALL --password secret \
+    --no-audio --server wss://991a.lima11.de/ws/rig
+```
 Bei den Parametern `--server` und `--audio-server` darf auch eine HTTP(S)-Adresse
 angegeben werden. Das Programm wandelt diese automatisch in das passende
 WebSocket-Schema (`ws://` bzw. `wss://`) um.


### PR DESCRIPTION
## Summary
- add `--no-audio` option to disable sound
- handle missing audio devices gracefully
- warn when no credentials are supplied
- document the new flag

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `python flask_server.py` (fails: port already in use)
- `python flask_server.py`
- `python trx/ft991a_ws_server.py --server ws://localhost:8084/ws/rig --username admin --password admin --no-audio --serial-port /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_687a4f43d98883218edf9cca0ce95e70