### PR TITLE
Mode-Verarbeitung auf CAT-Hexcode umgestellt

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -105,6 +105,7 @@ AUDIO_CLIENTS = {}
 AUDIO_CLIENTS_LOCK = threading.Lock()
 RIG_LIST_CLIENTS = set()
 RIG_LIST_LOCK = threading.Lock()
+ERLAUBTE_MODE_CODES = {f'{code:02X}' for code in range(0x01, 0x0F)}
 
 GERMAN_PREFIXES = (
     'DA', 'DB', 'DC', 'DD', 'DF', 'DG', 'DH', 'DJ',
@@ -121,6 +122,20 @@ def is_valid_callsign(callsign):
 def has_operator_rights():
     """True, wenn der angemeldete Nutzer einen TRX bedienen darf."""
     return session.get('role') == 'admin' or session.get('approved')
+
+
+def normalize_mode_code(value):
+    """Mode-Eingabe in zweistelligen CAT-Code (01..0E) normalisieren."""
+    normalized = (value or '').strip().upper()
+    if normalized in ERLAUBTE_MODE_CODES:
+        return normalized
+    try:
+        mode_num = int(normalized, 16)
+    except ValueError:
+        return None
+    if 0x01 <= mode_num <= 0x0E:
+        return f'{mode_num:02X}'
+    return None
 
 TEMPLATES_DIR = os.path.join(BASE_DIR, 'templates')
 STATIC_DIR = os.path.join(BASE_DIR, 'static')
@@ -885,11 +900,10 @@ def command():
             except ValueError:
                 return ('', 204)
         elif cmd == 'mode':
-            try:
-                mode = int(value)
-                data = {'command': 'set_mode', 'mode': mode}
-            except ValueError:
-                return ('', 204)
+            mode = normalize_mode_code(value)
+            if mode is None:
+                return ('Ungültiger Moduscode. Erlaubt sind 01 bis 0E.', 400)
+            data = {'command': 'set_mode', 'mode': mode}
         elif cmd == 'ptt_on':
             data = {'command': 'ptt_on'}
         elif cmd == 'ptt_off':
@@ -976,11 +990,10 @@ def command():
             except ValueError:
                 return ('', 204)
         elif cmd == 'mode':
-            try:
-                mode = int(value)
-                data = {'command': 'set_mode', 'mode': mode}
-            except ValueError:
-                return ('', 204)
+            mode = normalize_mode_code(value)
+            if mode is None:
+                return ('Ungültiger Moduscode. Erlaubt sind 01 bis 0E.', 400)
+            data = {'command': 'set_mode', 'mode': mode}
         elif cmd == 'ptt_on':
             data = {'command': 'ptt_on'}
         elif cmd == 'ptt_off':


### PR DESCRIPTION
### Motivation
- Mode-Eingaben sollen robust als zweistellige CAT-Hexcodes (`01`..`0E`) behandelt und gegen typische UI-Formate (Whitespace, Kleinschreibung) validiert werden.
- Statt stiller `204`-Antworten soll ein ungültiger Moduscode eine sinnvolle Fehlermeldung mit geeignetem HTTP-Status liefern.

### Description
- Neue Menge `ERLAUBTE_MODE_CODES` und Funktion `normalize_mode_code(value)` ergänzt, die Eingaben trimmt, uppercaset, Hex-Parsing durchführt und gültige Codes als zweistelligen Hex-String zurückgibt.
- In beiden `command()`-Zweigen (`REMOTE_SERVER` und `RIGS`) die Verarbeitung von `cmd == 'mode'` auf `normalize_mode_code` umgestellt und der Rückgabewert als CAT-Mode weitergereicht.
- Ungültige Mode-Eingaben führen jetzt zu einer klaren Fehlmeldung `('Ungültiger Moduscode. Erlaubt sind 01 bis 0E.', 400)` anstelle eines stillen `204`.
- Bestehende UI-Werte wie `01`..`09` und `0A`..`0E` werden akzeptiert (inkl. Whitespace und Kleinschreibung).

### Testing
- `python -m py_compile $(git ls-files '*.py')` wurde ausgeführt und hat bestanden.
- Ein AST-basierter Unit-Check für `ERLAUBTE_MODE_CODES` und `normalize_mode_code` mit mehreren gültigen/ungültigen Eingaben wurde ausgeführt und war erfolgreich.
- Ein direkter Laufimport-Test (`from flask_server import normalize_mode_code`) schlug in der aktuellen Umgebung fehl wegen fehlender Laufzeitabhängigkeit `websockets`, weshalb die isolierten Prüfungen per AST/kompilierter Funktion verwendet wurden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4dcf7e588321aa42067f88545687)