### PR TITLE
REMOTE_SERVER: Sendestatus unterscheiden und 204 für Schreibbefehle

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -6,6 +6,7 @@ import os
 import re
 import websockets
 import logging
+from enum import Enum
 from collections import deque
 from flask import Flask, render_template, request, redirect, session, url_for, jsonify
 import datetime
@@ -892,6 +893,12 @@ def command():
     cmd = request.form.get('cmd')
     value = request.form.get('value', '')
     if REMOTE_SERVER:
+        class RemoteSendStatus(Enum):
+            """Statuswerte fuer das Senden eines Remote-Kommandos."""
+            SENT_NO_RESPONSE = 'sent_no_response'
+            RESPONSE_RECEIVED = 'response_received'
+            ERROR = 'error'
+
         data = {'command': None}
         if cmd == 'frequency':
             try:
@@ -967,14 +974,16 @@ def command():
                 async with websockets.connect(REMOTE_SERVER) as ws:
                     await ws.send(json.dumps(data))
                     if cmd in ('get_frequency', 'get_mode', 'get_smeter'):
-                        return await ws.recv()
+                        return (RemoteSendStatus.RESPONSE_RECEIVED, await ws.recv())
+                    return (RemoteSendStatus.SENT_NO_RESPONSE, None)
             except Exception:
                 logger.exception('Remote command failed')
-                return None
-            return None
-        resp = asyncio.run(send())
-        if resp is not None:
+                return (RemoteSendStatus.ERROR, None)
+        status, resp = asyncio.run(send())
+        if status == RemoteSendStatus.RESPONSE_RECEIVED:
             return resp
+        if status == RemoteSendStatus.SENT_NO_RESPONSE:
+            return ('', 204)
         return ('Kein TRX verbunden', 200)
     elif RIGS:
         rig = session.get('rig')


### PR DESCRIPTION
### Motivation
- Aktuelles Verhalten im `REMOTE_SERVER`-Zweig gab bei Schreibbefehlen fälschlich die Meldung „Kein TRX verbunden“ zurück, obwohl das Senden erfolgreich war. 
- Es soll klar zwischen „gesendet ohne Antwort“, „Antwort erhalten“ und „Fehler“ unterschieden werden, damit HTTP-Antworten semantisch korrekt sind. 
- Lesebefehle sollen weiterhin erhaltene Antworten direkt zurückgeben.

### Description
- `Enum` importiert und innerhalb des `REMOTE_SERVER`-Zweigs ein `RemoteSendStatus`-Enum (`SENT_NO_RESPONSE`, `RESPONSE_RECEIVED`, `ERROR`) eingeführt. 
- Die asynchrone Hilfsfunktion `send()` gibt nun ein Tupel `(status, response)` zurück und verwendet das Enum, wobei Lesebefehle (`get_frequency`, `get_mode`, `get_smeter`) `RESPONSE_RECEIVED` liefern und Schreibbefehle `SENT_NO_RESPONSE`. 
- Nach `asyncio.run(send())` wird der Status ausgewertet: bei `RESPONSE_RECEIVED` wird die TRX-Antwort zurückgegeben, bei `SENT_NO_RESPONSE` wird `204 No Content` zurückgegeben, und bei `ERROR` wird weiterhin `('Kein TRX verbunden', 200)` geliefert. 
- Die Änderung beschränkt sich auf den `REMOTE_SERVER`-Zweig von `command()` und lässt das Verhalten der `RIGS`-Verarbeitung unverändert.

### Testing
- Syntaxprüfung mit `python -m py_compile $(git ls-files '*.py')` erfolgreich ausgeführt. 
- Direkte Kompilierung mit `python -m py_compile flask_server.py` erfolgreich ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5024f1408321ab94aba13a42a0ae)