### PR TITLE
Entkopple RIG_LOCK von WebSocket-I/O in `command()`

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -1061,12 +1061,26 @@ def command():
         else:
             return ('', 204)
 
-        with RIG_LOCK:
+        try:
             ws.send(json.dumps(data))
-            if cmd in ('get_frequency', 'get_mode', 'get_smeter'):
+        except Exception:
+            logger.exception('Senden an TRX fehlgeschlagen')
+            with RIG_LOCK:
+                if RIGS.get(rig) is ws:
+                    RIGS.pop(rig, None)
+            return ('Kein TRX verbunden', 200)
+
+        if cmd in ('get_frequency', 'get_mode', 'get_smeter'):
+            try:
                 resp = ws.receive()
-                if resp:
-                    return resp
+            except Exception:
+                logger.exception('Empfang vom TRX fehlgeschlagen')
+                with RIG_LOCK:
+                    if RIGS.get(rig) is ws:
+                        RIGS.pop(rig, None)
+                return ('Kein TRX verbunden', 200)
+            if resp:
+                return resp
     else:
         return ('Kein TRX verbunden', 200)
     return ('', 204)


### PR DESCRIPTION
### Motivation
- Vermeiden, dass ein globaler Lock während blockierender WebSocket-I/O gehalten wird, um Deadlocks und Thread-Blockaden zu verhindern.
- Sicherstellen, dass fehlerhafte/abgekoppelte WebSocket-Verbindungen konsistent aus `RIGS` entfernt werden und die API eine sinnvolle Antwort liefert.

### Description
- Verschiebe blockierende WebSocket-Operationen (`ws.send(...)`, `ws.receive()`) aus dem Bereich, der `RIG_LOCK` hält, so dass unter dem Lock nur noch auf die `ws`-Referenz zugegriffen wird.
- Ergänze `try/except`-Blöcke um `ws.send` und um `ws.receive`, um Sende- und Empfangsfehler zu behandeln und Ausnahmen zu protokollieren (`logger.exception`).
- Entferne bei Fehlern unter Schutz von `RIG_LOCK` die veraltete Socket-Referenz aus `RIGS`, sofern der Eintrag weiterhin auf das fehlerhafte `ws` zeigt.
- Gebe bei Fehlern eine konsistente Antwort zurück (`('Kein TRX verbunden', 200)`) und stelle sicher, dass während blockierender I/O kein globaler Lock gehalten wird.

### Testing
- `python -m py_compile $(git ls-files '*.py')` wurde ausgeführt und lieferte keine Syntaxfehler (erfolgreich).
- `pytest -q` wurde ausgeführt, es wurden jedoch keine Tests gefunden (`no tests ran`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5337ca488321840334fdc2d0cea0)