### PR TITLE
Erzwinge sichere Secret-Konfiguration für flask_server.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,15 @@ Funkgeräts selbst und wird daher immer im TRX-Modus betrieben.
 
 ### Flask‑Server auf dem Client (Linux)
 
-1. Auf dem Linux‑Rechner die Weboberfläche starten. Der Server nutzt standardmäßig keine serielle Schnittstelle, sondern wartet auf eingehende WebSocket‑Verbindungen des Steuerungsdienstes:
+1. Auf dem Linux‑Rechner die Weboberfläche starten. Der Server nutzt standardmäßig keine serielle Schnittstelle, sondern wartet auf eingehende WebSocket‑Verbindungen des Steuerungsdienstes.
+   **Wichtig:** Das Flask‑Secret ist Pflicht und muss über `--secret` oder die Umgebungsvariable `FLASK_SECRET_KEY` gesetzt werden:
    ```bash
+   export FLASK_SECRET_KEY='bitte-ein-langes-zufaelliges-secret'
    python flask_server.py
+   ```
+   Alternativ direkt per Argument:
+   ```bash
+   python flask_server.py --secret 'bitte-ein-langes-zufaelliges-secret'
    ```
    Mit dem Parameter `--server` kann optional ein externer Dienst angesprochen werden. Die Anwendung läuft immer auf Port 8084.
    Beim ersten Start existiert lediglich der Benutzer `admin` mit dem Passwort `admin`. Dieses Konto muss sich nach dem Login umbenennen und ein neues Passwort vergeben.

--- a/flask_server.py
+++ b/flask_server.py
@@ -142,8 +142,7 @@ TEMPLATES_DIR = os.path.join(BASE_DIR, 'templates')
 STATIC_DIR = os.path.join(BASE_DIR, 'static')
 app = Flask(__name__, template_folder=TEMPLATES_DIR,
             static_folder=STATIC_DIR)
-DEFAULT_SECRET = 'change-me'
-app.secret_key = DEFAULT_SECRET
+app.secret_key = None
 CURRENT_YEAR = datetime.datetime.now().year
 EU_BERLIN = ZoneInfo('Europe/Berlin')
 
@@ -1245,8 +1244,8 @@ def main():
     parser = argparse.ArgumentParser(description='FT-991A remote server')
     parser.add_argument('--server', default=DEFAULT_REMOTE_SERVER,
                         help='Remote control server wss://host:port')
-    parser.add_argument('--secret', default=DEFAULT_SECRET,
-                        help='Flask secret key')
+    parser.add_argument('--secret', default=None,
+                        help='Flask secret key (alternativ via FLASK_SECRET_KEY)')
     parser.add_argument('--input-device', type=int, default=None,
                         help='Audio input device index')
     parser.add_argument('--output-device', type=int, default=None,
@@ -1254,8 +1253,6 @@ def main():
     parser.add_argument('--list-devices', action='store_true',
                         help='List audio devices and exit')
     args = parser.parse_args()
-
-    app.secret_key = args.secret
     global INPUT_DEVICE_INDEX, OUTPUT_DEVICE_INDEX
     INPUT_DEVICE_INDEX = args.input_device
     OUTPUT_DEVICE_INDEX = args.output_device
@@ -1279,6 +1276,16 @@ def main():
                     print(f"  {i}: {name}")
             p.terminate()
         return
+
+    # Zweck: Secret sicher aus CLI oder Umgebung laden und unsicheren Start verhindern.
+    # Nutzung: --secret hat Vorrang, ansonsten FLASK_SECRET_KEY setzen.
+    configured_secret = args.secret or os.environ.get('FLASK_SECRET_KEY')
+    if not configured_secret:
+        raise SystemExit(
+            'Fehler: Kein Flask-Secret gesetzt. Bitte --secret angeben '
+            'oder die Umgebungsvariable FLASK_SECRET_KEY setzen.'
+        )
+    app.secret_key = configured_secret
 
     REMOTE_SERVER = args.server
     # The web interface always runs on port 8084


### PR DESCRIPTION
### Motivation

- Verhindern, dass der Server mit einem unsicheren Fixwert für das Flask-Secret gestartet wird, da dies ein Sicherheitsrisiko für Sessions und Cookies darstellt.
- Sicherstellen, dass das Secret beim Start bewusst gesetzt wird, entweder per CLI-Argument oder per Umgebungsvariable.

### Description

- Entfernt die produktive Voreinstellung `DEFAULT_SECRET = 'change-me'` und setzt `app.secret_key` initial auf `None` in `flask_server.py`.
- Führt eine Auflösung des Secrets ein, die zuerst das CLI-Argument `--secret` und ansonsten die Umgebungsvariable `FLASK_SECRET_KEY` verwendet.
- Bricht der Start ab, wenn kein Secret gesetzt ist, und gibt eine klare deutsche Fehlermeldung aus (`SystemExit` mit Text: `Fehler: Kein Flask-Secret gesetzt...`).
- Ergänzt `README.md` im Abschnitt zum Start des Flask-Servers mit Hinweisen zur Pflichtkonfiguration des Secrets und Beispielen für `--secret` bzw. `FLASK_SECRET_KEY`.

### Testing

- `python -m py_compile $(git ls-files '*.py')` wurde ausgeführt und erfolgreich beendet.
- `python flask_server.py` (ohne Secret) wurde ausgeführt und brach erwartungsgemäß mit der deutschen Fehlermeldung ab.
- `timeout 3 env FLASK_SECRET_KEY=testsecret python flask_server.py` wurde ausgeführt und der Server startete erfolgreich (Laufzeit-Test mit Timeout bestätigte Startsequenz).
- `timeout 3 python flask_server.py --secret cli_secret` wurde ausgeführt und der Server startete erfolgreich (Laufzeit-Test mit Timeout bestätigte Startsequenz); das komplette `pip install -r requirements.txt` scheiterte in dieser Umgebung beim Bau von `pyaudio` wegen fehlendem PortAudio-Header, daher wurden die Änderungen mit den minimalen Laufzeitabhängigkeiten (`flask`, `flask-sock`, `websockets`) verifiziert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee54a32ba0832195d620b9103a7137)