### PR TITLE
Einheitlichen CSRF-Schutz für Formulare und Fetch-Aufrufe ergänzen

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import re
+import secrets
 import websockets
 import logging
 from enum import Enum
@@ -125,6 +126,26 @@ def has_operator_rights():
     return session.get('role') == 'admin' or session.get('approved')
 
 
+def get_csrf_token():
+    """CSRF-Token pro Sitzung erzeugen und zurückgeben."""
+    token = session.get('csrf_token')
+    if not token:
+        token = secrets.token_urlsafe(32)
+        session['csrf_token'] = token
+    return token
+
+
+def is_valid_csrf():
+    """CSRF-Token aus Formular oder Header gegen Session prüfen."""
+    expected = session.get('csrf_token')
+    if not expected:
+        return False
+    provided = request.form.get('csrf_token') or request.headers.get('X-CSRF-Token')
+    if not provided:
+        return False
+    return secrets.compare_digest(provided, expected)
+
+
 def normalize_mode_code(value):
     """Mode-Eingabe in zweistelligen CAT-Code (01..0E) normalisieren."""
     normalized = (value or '').strip().upper()
@@ -161,6 +182,19 @@ GITHUB_VERSION = _get_github_version()
 PROGRAM_VERSION = f'FT-991A-Remote V0.1.{GITHUB_VERSION}'
 
 sock = Sock(app)
+
+
+@app.context_processor
+def inject_csrf_token():
+    """CSRF-Token in allen Templates bereitstellen."""
+    return {'csrf_token': get_csrf_token()}
+
+
+@app.before_request
+def enforce_csrf_protection():
+    """Alle POST-Requests ohne gültiges CSRF-Token mit 403 ablehnen."""
+    if request.method == 'POST' and not is_valid_csrf():
+        return ('CSRF-Token ungültig oder fehlt.', 403)
 
 
 def load_answer_commands():

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     <title>{% block title %}{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>

--- a/templates/change_credentials.html
+++ b/templates/change_credentials.html
@@ -6,6 +6,7 @@
     <p>Angemeldet als {{ current }} ({{ role }})</p>
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <label>Benutzername: <input type="text" name="username" value="{{ current }}"></label><br>
         <label>Neues Passwort: <input type="password" name="password"></label><br>
         <button type="submit">Speichern</button>

--- a/templates/create_user.html
+++ b/templates/create_user.html
@@ -5,6 +5,7 @@
 {% block content %}
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <label>Benutzername: <input type="text" name="username"></label><br>
         <label>Passwort: <input type="password" name="password"></label><br>
         <label>Rolle:

--- a/templates/edit_user.html
+++ b/templates/edit_user.html
@@ -5,6 +5,7 @@
 {% block content %}
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <label>Benutzername: <input type="text" name="username" value="{{ username }}"></label><br>
         <label>Neues Passwort: <input type="password" name="password"></label><br>
         <label>Rolle:

--- a/templates/index.html
+++ b/templates/index.html
@@ -366,6 +366,7 @@
 {% block scripts %}
 <script>
 const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
+const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content || '';
 const currentUser = '{{ user }}';
 let isOperator = {{ 'true' if operator==user else 'false' }};
 let sock;
@@ -574,9 +575,20 @@ function stopRigList(){
     if(rigListSock){ rigListSock.close(); rigListSock=null; }
 }
 document.querySelectorAll('.cmdForm').forEach(f => {
+    if(!f.querySelector('input[name="csrf_token"]')){
+        const csrfInput = document.createElement('input');
+        csrfInput.type = 'hidden';
+        csrfInput.name = 'csrf_token';
+        csrfInput.value = csrfToken;
+        f.appendChild(csrfInput);
+    }
     f.addEventListener('submit', e => {
         e.preventDefault();
-        fetch(f.action, {method:'POST', body:new FormData(f)})
+        fetch(f.action, {
+            method:'POST',
+            body:new FormData(f),
+            headers:{'X-CSRF-Token': csrfToken}
+        })
             .then(r => {
                 if(r.redirected){
                     window.location.href = r.url;
@@ -590,7 +602,12 @@ document.querySelectorAll('.cmdForm').forEach(f => {
 function sendPTT(on){
     const fd = new FormData();
     fd.append('cmd', on ? 'ptt_on' : 'ptt_off');
-    fetch('{{ url_for('command') }}', {method: 'POST', body: fd});
+    fd.append('csrf_token', csrfToken);
+    fetch('{{ url_for('command') }}', {
+        method: 'POST',
+        body: fd,
+        headers:{'X-CSRF-Token': csrfToken}
+    });
 }
 function startPTT(){
     if(!startPTT.active){
@@ -626,7 +643,7 @@ async function ping(){
         await fetch('{{ url_for('heartbeat') }}', {
             method:'POST',
             credentials:'same-origin',
-            headers:{'Content-Type':'application/json'},
+            headers:{'Content-Type':'application/json','X-CSRF-Token': csrfToken},
             body: JSON.stringify({rtt:lastRtt})
         });
         lastRtt = Math.round(performance.now() - start);
@@ -665,7 +682,12 @@ async function ping(){
             rigSel.onchange = () => {
                 const fd = new FormData();
                 fd.append('rig', rigSel.value);
-                fetch('{{ url_for('select_rig') }}', {method:'POST', body: fd}).then(() => ping());
+                fd.append('csrf_token', csrfToken);
+                fetch('{{ url_for('select_rig') }}', {
+                    method:'POST',
+                    body: fd,
+                    headers:{'X-CSRF-Token': csrfToken}
+                }).then(() => ping());
             };
         }
         const memSel = document.querySelector('#memory-select select[name="value"]');
@@ -713,7 +735,12 @@ if(rigSelectInit){
     rigSelectInit.onchange = () => {
         const fd = new FormData();
         fd.append('rig', rigSelectInit.value);
-        fetch('{{ url_for('select_rig') }}', {method:'POST', body: fd}).then(() => ping());
+        fd.append('csrf_token', csrfToken);
+        fetch('{{ url_for('select_rig') }}', {
+            method:'POST',
+            body: fd,
+            headers:{'X-CSRF-Token': csrfToken}
+        }).then(() => ping());
     };
 }
 </script>

--- a/templates/login.html
+++ b/templates/login.html
@@ -5,6 +5,7 @@
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     {% if message %}<p style="color:green;">{{ message }}</p>{% endif %}
     <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <label>Benutzername: <input type="text" name="username"></label><br>
         <label>Passwort: <input type="password" name="password"></label><br>
         <button type="submit">Anmelden</button>

--- a/templates/register.html
+++ b/templates/register.html
@@ -4,6 +4,7 @@
 {% block content %}
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <label>Rufzeichen: <input type="text" name="username"></label><br>
         <label>Passwort: <input type="password" name="password"></label><br>
         <button type="submit">Registrieren</button>

--- a/templates/userlist.html
+++ b/templates/userlist.html
@@ -16,26 +16,31 @@
             <td>{{ u.last_login_local }}</td>
             <td>
                 <form method="post" style="display:inline">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="username" value="{{ name }}">
                     <input type="hidden" name="action" value="approve">
                     <button type="submit">Freischalten</button>
                 </form>
                 <form method="post" style="display:inline">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="username" value="{{ name }}">
                     <input type="hidden" name="action" value="make_admin">
                     <button type="submit">Admin machen</button>
                 </form>
                 <form method="post" style="display:inline">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="username" value="{{ name }}">
                     <input type="hidden" name="action" value="remove_admin">
                     <button type="submit">Admin entziehen</button>
                 </form>
                 <form method="post" style="display:inline">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="username" value="{{ name }}">
                     <input type="hidden" name="action" value="make_trx">
                     <button type="submit">TRX zuweisen</button>
                 </form>
                 <form method="post" style="display:inline">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     <input type="hidden" name="username" value="{{ name }}">
                     <input type="hidden" name="action" value="remove_trx">
                     <button type="submit">TRX entfernen</button>


### PR DESCRIPTION
### Motivation
- Schutz gegen Cross-Site-Request-Forgery einführen, insbesondere für Admin-Aktionen und das `/command`-Endpoint.
- Konsistente Übertragung des Tokens sowohl per verstecktem Formularfeld als auch per Header für Fetch/JS-Aufrufe sicherstellen.
- Minimale, framework-unabhängige Lösung ohne externe Abhängigkeit (einfacher Session-Token + Middleware) bereitstellen.

### Description
- Server: In `flask_server.py` wurden `get_csrf_token()` und `is_valid_csrf()` ergänzt und ein `@app.before_request`-Hook `enforce_csrf_protection()` eingefügt, der alle POST-Requests ohne gültiges Token mit HTTP 403 ablehnt.
- Templates: CSRF-Token via Context-Processor in alle Templates injiziert und ein Meta-Tag in `templates/base.html` ergänzt; in folgenden Formular-Templates ein Hidden-Feld `<input name="csrf_token">` ergänzt: `login.html`, `register.html`, `change_credentials.html`, `userlist.html`, `create_user.html`, `edit_user.html`.
- JavaScript: In `templates/index.html` wird das Token aus dem Meta-Tag gelesen; `.cmdForm`-Formulare erhalten automatisch ein Hidden-Feld, alle relevanten `fetch()`-Aufrufe senden zusätzlich den Header `X-CSRF-Token`, und dynamische FormData-POSTs (z.B. `/command`, `/select_rig`, Heartbeat) fügen `csrf_token` hinzu.
- Wirkung: Admin-Aktionen (Benutzer freischalten, Rolle ändern, TRX-Zuweisung) und alle POST-Endpunkte (inkl. `/command`) sind nun gegen CSRF abgesichert.

### Testing
- `python -m py_compile $(git ls-files '*.py')` wurde ausgeführt und war erfolgreich.
- Versuch eines Flask-Testclient-Checks zur Validierung der CSRF-Logik scheiterte in der Laufumgebung wegen fehlender Abhängigkeit `websockets`, weshalb dieser Test hier nicht vollständig ausgeführt werden konnte.
- Statische Überprüfung: Templates und JavaScript wurden auf korrekte Einbindung des Tokens angepasst und Änderungen wurden committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee55f66698832183138cd4fb128b23)